### PR TITLE
Release v0.0.6: Add interval/note filtering to Learn mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Guitar Theory Lab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2026-01-02
+
+### Added
+- Interval/Note filtering functionality in Learn mode
+  - New IntervalFilter component with checkboxes for each interval (R, b2, 2, b3, 3, 4, b5, 5, b6, 6, b7, 7)
+  - Filter toggles dynamically switch between interval names and actual note names based on root
+  - "All" and "None" buttons for quick filter selection
+  - Unchecked intervals/notes are hidden from the fretboard display
+  - Works seamlessly with both "Show Intervals" mode and note display mode
+  - Allows selective study of specific intervals or notes (e.g., hide all 4ths, show only root and 5th, etc.)
+
 ## [0.0.5] - 2026-01-02
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,22 @@ function App() {
   const [showIntervals, setShowIntervals] = useState(false);
   const [tabView, setTabView] = useState(false);
 
+  // Filter state for intervals/notes
+  const [filteredIntervals, setFilteredIntervals] = useState({
+    0: true,   // R (Root)
+    1: true,   // b2
+    2: true,   // 2
+    3: true,   // b3
+    4: true,   // 3
+    5: true,   // 4
+    6: true,   // b5
+    7: true,   // 5
+    8: true,   // b6
+    9: true,   // 6
+    10: true,  // b7
+    11: true   // 7
+  });
+
   // Jam mode state
   const [jamHighlight, setJamHighlight] = useState({ notes: [], rootNote: 'A', mode: 'scale' });
   const handleJamHighlightChange = useCallback((data) => {
@@ -99,6 +115,8 @@ function App() {
               setShowIntervals={setShowIntervals}
               tabView={tabView}
               setTabView={setTabView}
+              filteredIntervals={filteredIntervals}
+              setFilteredIntervals={setFilteredIntervals}
             />
 
             <Reference
@@ -115,6 +133,7 @@ function App() {
               showIntervals={showIntervals}
               mode={mode}
               tabView={tabView}
+              filteredIntervals={filteredIntervals}
             />
           </>
         ) : activeTab === 'practice' ? (

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -2,6 +2,7 @@ import { NOTES } from '../../data/notes';
 import { TUNINGS, getTuningOptions } from '../../data/tunings';
 import { getScaleOptions } from '../../data/scales';
 import { getChordOptions } from '../../data/chords';
+import IntervalFilter from '../IntervalFilter/IntervalFilter';
 import './Controls.css';
 
 function Controls({
@@ -18,7 +19,9 @@ function Controls({
   showIntervals,
   setShowIntervals,
   tabView,
-  setTabView
+  setTabView,
+  filteredIntervals,
+  setFilteredIntervals
 }) {
   const tuningOptions = getTuningOptions();
   const scaleOptions = getScaleOptions();
@@ -118,6 +121,13 @@ function Controls({
           Invert Strings
         </label>
       </div>
+
+      <IntervalFilter
+        showIntervals={showIntervals}
+        filteredIntervals={filteredIntervals}
+        setFilteredIntervals={setFilteredIntervals}
+        rootNote={rootNote}
+      />
     </div>
   );
 }

--- a/src/components/Fretboard/Fretboard.jsx
+++ b/src/components/Fretboard/Fretboard.jsx
@@ -12,7 +12,8 @@ function Fretboard({
   tabView,
   practiceMode = false,
   onFretClick = null,
-  revealedFrets = []
+  revealedFrets = [],
+  filteredIntervals = null
 }) {
   const fretboardData = useMemo(() => {
     const data = tuning.map((openNote, stringIndex) => {
@@ -43,6 +44,15 @@ function Fretboard({
     }
 
     if (!highlightedNotes.length) return 'inactive';
+
+    // Check if this note should be filtered out
+    if (filteredIntervals && highlightedNotes.includes(note)) {
+      const interval = getIntervalFromRoot(note, rootNote);
+      if (!filteredIntervals[interval]) {
+        return 'inactive';
+      }
+    }
+
     if (note === rootNote) return 'root';
     if (highlightedNotes.includes(note)) {
       return mode === 'chord' ? 'chord' : 'highlighted';

--- a/src/components/IntervalFilter/IntervalFilter.css
+++ b/src/components/IntervalFilter/IntervalFilter.css
@@ -1,0 +1,96 @@
+.interval-filter {
+  margin: 15px 20px;
+  padding: 15px;
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.filter-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.filter-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.filter-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.filter-action-btn {
+  padding: 4px 12px;
+  font-size: 12px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.filter-action-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--primary);
+}
+
+.filter-checkboxes {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 10px;
+}
+
+.filter-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  padding: 6px 8px;
+  background: var(--bg-tertiary);
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.filter-checkbox:hover {
+  background: var(--bg-hover);
+}
+
+.filter-checkbox input[type="checkbox"] {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  accent-color: var(--primary);
+}
+
+.checkbox-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  user-select: none;
+}
+
+.checkbox-label.root-label {
+  color: var(--note-root);
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .filter-checkboxes {
+    grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
+    gap: 8px;
+  }
+
+  .filter-checkbox {
+    padding: 5px 6px;
+  }
+
+  .checkbox-label {
+    font-size: 12px;
+  }
+}

--- a/src/components/IntervalFilter/IntervalFilter.jsx
+++ b/src/components/IntervalFilter/IntervalFilter.jsx
@@ -1,0 +1,90 @@
+import './IntervalFilter.css';
+
+const INTERVAL_LABELS = {
+  0: 'R',
+  1: 'b2',
+  2: '2',
+  3: 'b3',
+  4: '3',
+  5: '4',
+  6: 'b5',
+  7: '5',
+  8: 'b6',
+  9: '6',
+  10: 'b7',
+  11: '7'
+};
+
+const NOTES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+function IntervalFilter({ showIntervals, filteredIntervals, setFilteredIntervals, rootNote }) {
+  const handleToggle = (interval) => {
+    setFilteredIntervals(prev => ({
+      ...prev,
+      [interval]: !prev[interval]
+    }));
+  };
+
+  const handleToggleAll = (enabled) => {
+    const newFilters = {};
+    for (let i = 0; i <= 11; i++) {
+      newFilters[i] = enabled;
+    }
+    setFilteredIntervals(newFilters);
+  };
+
+  // Get the note for each interval based on root note
+  const getNoteForInterval = (interval) => {
+    const rootIndex = NOTES.indexOf(rootNote);
+    if (rootIndex === -1) return '?';
+    const targetIndex = (rootIndex + interval) % 12;
+    return NOTES[targetIndex];
+  };
+
+  return (
+    <div className="interval-filter">
+      <div className="filter-header">
+        <span className="filter-title">
+          {showIntervals ? 'Filter Intervals' : 'Filter Notes'}
+        </span>
+        <div className="filter-actions">
+          <button
+            className="filter-action-btn"
+            onClick={() => handleToggleAll(true)}
+          >
+            All
+          </button>
+          <button
+            className="filter-action-btn"
+            onClick={() => handleToggleAll(false)}
+          >
+            None
+          </button>
+        </div>
+      </div>
+      <div className="filter-checkboxes">
+        {Object.keys(INTERVAL_LABELS).map(interval => {
+          const intervalNum = parseInt(interval);
+          const displayLabel = showIntervals
+            ? INTERVAL_LABELS[interval]
+            : getNoteForInterval(intervalNum);
+
+          return (
+            <label key={interval} className="filter-checkbox">
+              <input
+                type="checkbox"
+                checked={filteredIntervals[intervalNum]}
+                onChange={() => handleToggle(intervalNum)}
+              />
+              <span className={`checkbox-label ${intervalNum === 0 ? 'root-label' : ''}`}>
+                {displayLabel}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default IntervalFilter;


### PR DESCRIPTION
Added comprehensive filtering functionality that allows users to selectively show/hide specific intervals or notes on the fretboard:

- New IntervalFilter component with individual checkboxes for all 12 intervals
- Dynamic labels that switch between interval names (R, 2, 3, etc.) and actual note names based on root
- Quick "All" and "None" buttons for easy selection
- Filtered intervals/notes are hidden from fretboard display
- Works in both interval mode and note display mode
- Enables focused practice (e.g., study only root and 5th, hide all 4ths, etc.)

Updated components:
- App.jsx: Added filteredIntervals state management
- Controls.jsx: Integrated IntervalFilter component
- Fretboard.jsx: Implemented filtering logic in note display
- New IntervalFilter component with styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)