### PR TITLE
Release v0.0.7: Add adjustable fretboard length slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Guitar Theory Lab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7] - 2026-01-02
+
+### Added
+- Adjustable fretboard length slider
+  - New slider control to adjust fret count from 12 to 24 frets
+  - Displays current fret count above the slider
+  - Fretboard dynamically updates in real-time across all modes (Learn, Practice, Jam)
+  - Added fret 24 marker position with double dots (2nd octave)
+  - Smooth styled slider with hover effects and visual feedback
+
 ## [0.0.6] - 2026-01-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ function App() {
   const [chordType, setChordType] = useState('major');
   const [showIntervals, setShowIntervals] = useState(false);
   const [tabView, setTabView] = useState(false);
+  const [fretCount, setFretCount] = useState(22);
 
   // Filter state for intervals/notes
   const [filteredIntervals, setFilteredIntervals] = useState({
@@ -117,6 +118,8 @@ function App() {
               setTabView={setTabView}
               filteredIntervals={filteredIntervals}
               setFilteredIntervals={setFilteredIntervals}
+              fretCount={fretCount}
+              setFretCount={setFretCount}
             />
 
             <Reference
@@ -134,6 +137,7 @@ function App() {
               mode={mode}
               tabView={tabView}
               filteredIntervals={filteredIntervals}
+              fretCount={fretCount}
             />
           </>
         ) : activeTab === 'practice' ? (
@@ -174,6 +178,7 @@ function App() {
               practiceMode={true}
               onFretClick={handleFretClick}
               revealedFrets={revealedFrets}
+              fretCount={fretCount}
             />
           </>
         ) : activeTab === 'jam' ? (
@@ -215,6 +220,7 @@ function App() {
               showIntervals={false}
               mode={jamHighlight.mode}
               tabView={tabView}
+              fretCount={fretCount}
             />
           </>
         ) : null}

--- a/src/components/Controls/Controls.css
+++ b/src/components/Controls/Controls.css
@@ -74,3 +74,46 @@
   accent-color: var(--accent);
   cursor: pointer;
 }
+
+.fret-slider {
+  width: 100%;
+  min-width: 150px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--bg-tertiary);
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+}
+
+.fret-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.fret-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+  box-shadow: 0 0 8px var(--accent);
+}
+
+.fret-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s;
+}
+
+.fret-slider::-moz-range-thumb:hover {
+  transform: scale(1.2);
+  box-shadow: 0 0 8px var(--accent);
+}

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -21,7 +21,9 @@ function Controls({
   tabView,
   setTabView,
   filteredIntervals,
-  setFilteredIntervals
+  setFilteredIntervals,
+  fretCount,
+  setFretCount
 }) {
   const tuningOptions = getTuningOptions();
   const scaleOptions = getScaleOptions();
@@ -120,6 +122,20 @@ function Controls({
           />
           Invert Strings
         </label>
+      </div>
+
+      <div className="control-group">
+        <label>
+          Fret Count: {fretCount}
+        </label>
+        <input
+          type="range"
+          min="12"
+          max="24"
+          value={fretCount}
+          onChange={(e) => setFretCount(parseInt(e.target.value))}
+          className="fret-slider"
+        />
       </div>
 
       <IntervalFilter

--- a/src/components/Fretboard/Fretboard.jsx
+++ b/src/components/Fretboard/Fretboard.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { FRET_COUNT, FRET_MARKERS, DOUBLE_MARKERS, getNoteOnFret } from '../../data/notes';
+import { FRET_MARKERS, DOUBLE_MARKERS, getNoteOnFret } from '../../data/notes';
 import { getIntervalFromRoot } from '../../utils/musicTheory';
 import './Fretboard.css';
 
@@ -13,12 +13,13 @@ function Fretboard({
   practiceMode = false,
   onFretClick = null,
   revealedFrets = [],
-  filteredIntervals = null
+  filteredIntervals = null,
+  fretCount = 22
 }) {
   const fretboardData = useMemo(() => {
     const data = tuning.map((openNote, stringIndex) => {
       const frets = [];
-      for (let fret = 0; fret <= FRET_COUNT; fret++) {
+      for (let fret = 0; fret <= fretCount; fret++) {
         const note = getNoteOnFret(openNote, fret);
         frets.push({
           fret,
@@ -30,7 +31,7 @@ function Fretboard({
     });
     // Reverse for tab view (high E on top)
     return tabView ? [...data].reverse() : data;
-  }, [tuning, tabView]);
+  }, [tuning, tabView, fretCount]);
 
   const getNoteClass = (note, stringIdx, fret) => {
     if (practiceMode) {
@@ -108,7 +109,7 @@ function Fretboard({
           </div>
         ))}
         <div className="fret-markers">
-          {Array.from({ length: FRET_COUNT + 1 }, (_, fret) => (
+          {Array.from({ length: fretCount + 1 }, (_, fret) => (
             <div key={fret} className="fret-marker">
               {fret === 0 ? (
                 <span className="fret-number">0</span>

--- a/src/data/notes.js
+++ b/src/data/notes.js
@@ -38,5 +38,5 @@ export function getNoteOnFret(openNote, fret) {
 export const FRET_COUNT = 22;
 
 // Fret marker positions (dots on fretboard)
-export const FRET_MARKERS = [3, 5, 7, 9, 12, 15, 17, 19, 21];
-export const DOUBLE_MARKERS = [12]; // Octave markers (double dots)
+export const FRET_MARKERS = [3, 5, 7, 9, 12, 15, 17, 19, 21, 24];
+export const DOUBLE_MARKERS = [12, 24]; // Octave markers (double dots)


### PR DESCRIPTION
## Summary
- Added adjustable fretboard length slider allowing users to dynamically control the number of visible frets (12-24)
- Real-time fretboard updates across all modes

## Changes
- **New Control**: Fret count slider with range from 12 to 24 frets
- **Dynamic Fretboard**: All fretboard instances (Learn, Practice, Jam) now respect the fret count setting
- **Extended Markers**: Added fret 24 to marker positions with double dots for 2nd octave
- **Styled Slider**: Custom slider styling with hover effects and visual feedback

## Features
- Slider displays current fret count above the control
- Smooth transitions as fretboard adjusts to new fret count
- Works seamlessly across all modes without page refresh
- Fret markers dynamically show/hide based on current fret count

## Updated Components
- `App.jsx`: Added fretCount state (default: 22) and passed to all Fretboard instances
- `Controls.jsx`: Added fret count slider UI with range input
- `Fretboard.jsx`: Accepts dynamic fretCount prop and generates frets accordingly
- `Controls.css`: Added custom slider styling for webkit and mozilla browsers
- `notes.js`: Extended FRET_MARKERS and DOUBLE_MARKERS arrays to include fret 24

## Test Plan
- [x] Build and run dev server successfully
- [x] Verify slider appears in Learn mode controls
- [x] Adjust slider and verify fretboard length changes in real-time
- [x] Test in Practice mode - fretboard adjusts correctly
- [x] Test in Jam mode - fretboard adjusts correctly
- [x] Verify fret markers appear/disappear correctly (including 24th fret double dots)
- [x] Test min (12) and max (24) fret counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)