### PR TITLE
Release v0.0.8: Enhanced Jam mode chord audio and timing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Jam/Jam.css
+++ b/src/components/Jam/Jam.css
@@ -469,3 +469,99 @@
   color: var(--text-primary);
   border-radius: 4px;
 }
+
+/* Play Chord Button */
+.play-chord-btn {
+  background: #4CAF50;
+  border: none;
+  color: white;
+  font-size: 0.8em;
+  padding: 4px 8px;
+  width: auto;
+  height: auto;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0.85;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.play-chord-btn:hover {
+  background: #45a049;
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+.play-chord-btn:active {
+  transform: scale(0.95);
+}
+
+/* Chord Audio Controls in Global Settings */
+.chord-audio-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chord-audio-controls .toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.chord-audio-controls .toggle-label.active {
+  color: var(--accent);
+}
+
+.chord-audio-controls .toggle-label input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.volume-slider,
+.duration-slider {
+  width: 100%;
+  margin-top: 4px;
+  cursor: pointer;
+}
+
+.volume-slider:disabled,
+.duration-slider:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.waveform-select {
+  padding: 6px;
+  border-radius: 4px;
+  border: 1px solid var(--bg-tertiary);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.waveform-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Inline checkbox for step overrides */
+.inline-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 0.9em;
+}
+
+.inline-checkbox input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.inline-checkbox span {
+  cursor: pointer;
+}

--- a/src/components/Jam/SequenceStep.jsx
+++ b/src/components/Jam/SequenceStep.jsx
@@ -2,12 +2,16 @@ import { useState } from 'react';
 import { NOTES } from '../../data/notes';
 import { getScaleOptions } from '../../data/scales';
 import { getChordOptions } from '../../data/chords';
-import { TIME_SIGNATURES, hasOverrides } from '../../utils/jamSettings';
+import { TIME_SIGNATURES, hasOverrides, resolveStepSettings } from '../../utils/jamSettings';
 
-function SequenceStep({ step, onChange, onDelete, isActive, index }) {
+function SequenceStep({ step, onChange, onDelete, isActive, index, onPlayChord, globalSettings }) {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const scaleOptions = getScaleOptions();
   const chordOptions = getChordOptions();
+
+  // Check if chord audio is enabled for this step
+  const stepSettings = resolveStepSettings(step, globalSettings);
+  const isChordAudioEnabled = stepSettings.chordAudio.enabled;
 
   const handleChange = (field, value) => {
     onChange(step.id, { ...step, [field]: value });
@@ -50,6 +54,15 @@ function SequenceStep({ step, onChange, onDelete, isActive, index }) {
           >
             ⚙
           </button>
+          {isChordAudioEnabled && (
+            <button
+              className="play-chord-btn"
+              onClick={() => onPlayChord(step)}
+              title="Play Chord"
+            >
+              ▶
+            </button>
+          )}
           <button className="delete-btn" onClick={() => onDelete(step.id)} title="Remove">
             ×
           </button>
@@ -211,6 +224,85 @@ function SequenceStep({ step, onChange, onDelete, isActive, index }) {
                   <option value="eighth">Eighth</option>
                   <option value="triplet">Triplet</option>
                 </select>
+              </div>
+            )}
+          </div>
+
+          {/* Chord Audio Override */}
+          <div className="override-section">
+            <label className="override-checkbox">
+              <input
+                type="checkbox"
+                checked={isOverrideActive('chordAudio')}
+                onChange={() => toggleOverride('chordAudio', {
+                  enabled: true,
+                  volume: 0.25,
+                  duration: 0.8,
+                  waveform: 'sine'
+                })}
+              />
+              <span>Override Chord Audio</span>
+            </label>
+            {isOverrideActive('chordAudio') && (
+              <div className="override-controls">
+                <label className="inline-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={step.overrides.chordAudio.enabled}
+                    onChange={(e) => updateOverride('chordAudio', {
+                      ...step.overrides.chordAudio,
+                      enabled: e.target.checked
+                    })}
+                  />
+                  <span>Enabled</span>
+                </label>
+
+                <div className="control-row">
+                  <label>Volume: {(step.overrides.chordAudio.volume * 100).toFixed(0)}%</label>
+                  <input
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.05"
+                    value={step.overrides.chordAudio.volume}
+                    onChange={(e) => updateOverride('chordAudio', {
+                      ...step.overrides.chordAudio,
+                      volume: parseFloat(e.target.value)
+                    })}
+                    disabled={!step.overrides.chordAudio.enabled}
+                  />
+                </div>
+
+                <div className="control-row">
+                  <label>Duration: {step.overrides.chordAudio.duration.toFixed(1)}s</label>
+                  <input
+                    type="range"
+                    min="0.2"
+                    max="3.0"
+                    step="0.1"
+                    value={step.overrides.chordAudio.duration}
+                    onChange={(e) => updateOverride('chordAudio', {
+                      ...step.overrides.chordAudio,
+                      duration: parseFloat(e.target.value)
+                    })}
+                    disabled={!step.overrides.chordAudio.enabled}
+                  />
+                </div>
+
+                <div className="control-row">
+                  <label>Waveform:</label>
+                  <select
+                    value={step.overrides.chordAudio.waveform}
+                    onChange={(e) => updateOverride('chordAudio', {
+                      ...step.overrides.chordAudio,
+                      waveform: e.target.value
+                    })}
+                    disabled={!step.overrides.chordAudio.enabled}
+                  >
+                    <option value="sine">Sine</option>
+                    <option value="triangle">Triangle</option>
+                  </select>
+                </div>
               </div>
             )}
           </div>

--- a/src/utils/chordSounds.js
+++ b/src/utils/chordSounds.js
@@ -1,0 +1,118 @@
+/**
+ * Web Audio API chord sound generators
+ * Generates chord sounds using simple oscillators for lightweight performance
+ */
+
+import { getNoteIndex } from '../data/notes';
+
+/**
+ * Convert note name to frequency in Hz using equal temperament
+ * @param {string} note - Note name (e.g., "C", "D#", "Gb")
+ * @param {number} octave - Octave number (default: 4)
+ * @returns {number} Frequency in Hz
+ */
+export function noteToFrequency(note, octave = 4) {
+  // A4 = 440 Hz is the reference (index 9 in chromatic scale, octave 4)
+  const noteIndex = getNoteIndex(note);
+
+  // Calculate semitones from A4
+  // A is at index 9, so offset is noteIndex - 9
+  // Add octave difference: (octave - 4) * 12
+  const semitonesFromA4 = (noteIndex - 9) + ((octave - 4) * 12);
+
+  // Equal temperament formula: f = 440 * 2^(n/12)
+  const frequency = 440 * Math.pow(2, semitonesFromA4 / 12);
+
+  return frequency;
+}
+
+/**
+ * Determine optimal octave for each note in a chord voicing
+ * Creates musically pleasing voicings with root notes lower and extensions higher
+ * @param {Array<string>} notes - Array of note names
+ * @returns {Array<number>} Array of octave numbers for each note
+ */
+export function getChordVoicing(notes) {
+  const noteCount = notes.length;
+
+  if (noteCount === 0) return [];
+  if (noteCount === 1) return [4];
+  if (noteCount === 2) return [3, 4]; // Power chord style
+  if (noteCount === 3) return [3, 4, 4]; // Triad voicing
+  if (noteCount === 4) return [3, 4, 4, 5]; // 7th chord voicing
+
+  // 5+ notes: spread voicing for extended chords
+  return [3, 4, 4, 5, 5, ...Array(noteCount - 5).fill(5)];
+}
+
+/**
+ * Create and play a chord sound using Web Audio API
+ * @param {AudioContext} ctx - Web Audio context
+ * @param {number} time - Scheduled play time
+ * @param {Array<string>} notes - Array of note names to play
+ * @param {number} volume - Volume level (0.0-1.0, default: 0.25)
+ * @param {number} duration - Duration in seconds (default: 0.8)
+ * @param {string} waveform - Oscillator type ('sine' or 'triangle', default: 'sine')
+ */
+export function createChordSound(ctx, time, notes, volume = 0.25, duration = 0.8, waveform = 'sine') {
+  if (!ctx || !notes || notes.length === 0) return;
+
+  // Get voicing octaves for each note
+  const octaves = getChordVoicing(notes);
+
+  // Create an oscillator and gain node for each note
+  notes.forEach((note, index) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+
+    // Connect nodes: Oscillator → Gain → Destination
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+
+    // Set frequency based on note and octave
+    const frequency = noteToFrequency(note, octaves[index]);
+    osc.frequency.value = frequency;
+
+    // Set waveform (sine or triangle)
+    osc.type = waveform;
+
+    // Apply envelope: quick attack, sustain, fade out
+    const attackTime = 0.01; // 10ms attack
+    const releaseTime = 0.1; // 100ms release
+
+    // Start at 0, ramp up to volume quickly
+    gain.gain.setValueAtTime(0, time);
+    gain.gain.linearRampToValueAtTime(volume, time + attackTime);
+
+    // Hold at volume for duration
+    gain.gain.setValueAtTime(volume, time + duration - releaseTime);
+
+    // Fade out at the end
+    gain.gain.exponentialRampToValueAtTime(0.001, time + duration);
+
+    // Start and stop oscillator
+    osc.start(time);
+    osc.stop(time + duration);
+  });
+}
+
+/**
+ * Play chord immediately (for manual trigger button)
+ * @param {AudioContext} ctx - Web Audio context
+ * @param {Array<string>} notes - Array of note names to play
+ * @param {number} volume - Volume level (default: 0.25)
+ * @param {number} duration - Duration in seconds (default: 0.8)
+ * @param {string} waveform - Oscillator type (default: 'sine')
+ */
+export function playChordNow(ctx, notes, volume = 0.25, duration = 0.8, waveform = 'sine') {
+  if (!ctx) return;
+
+  // Resume audio context if suspended (browser autoplay policy)
+  if (ctx.state === 'suspended') {
+    ctx.resume().then(() => {
+      createChordSound(ctx, ctx.currentTime, notes, volume, duration, waveform);
+    });
+  } else {
+    createChordSound(ctx, ctx.currentTime, notes, volume, duration, waveform);
+  }
+}

--- a/src/utils/jamSettings.js
+++ b/src/utils/jamSettings.js
@@ -10,6 +10,12 @@ export const DEFAULT_GLOBAL_SETTINGS = {
   metronomeSound: {
     type: 'beep', // 'beep', 'click', 'woodblock'
     subdivision: 'quarter' // 'quarter', 'eighth', 'triplet'
+  },
+  chordAudio: {
+    enabled: true, // Enable/disable chord playback
+    volume: 0.25, // Volume level (0.0-1.0)
+    duration: 0.8, // Duration in seconds
+    waveform: 'sine' // Oscillator type ('sine' or 'triangle')
   }
 };
 
@@ -42,7 +48,13 @@ export function resolveStepSettings(step, globalSettings) {
     swingRatio: overrides.swingRatio !== null && overrides.swingRatio !== undefined
       ? overrides.swingRatio
       : globalSettings.swingRatio,
-    metronomeSound: overrides.metronomeSound || globalSettings.metronomeSound
+    metronomeSound: overrides.metronomeSound || globalSettings.metronomeSound,
+    chordAudio: overrides.chordAudio || globalSettings.chordAudio || {
+      enabled: true,
+      volume: 0.25,
+      duration: 0.8,
+      waveform: 'sine'
+    }
   };
 }
 
@@ -58,7 +70,8 @@ export function hasOverrides(step) {
          step.overrides.accentPattern !== null ||
          step.overrides.customAccents !== null ||
          (step.overrides.swingRatio !== null && step.overrides.swingRatio !== undefined) ||
-         step.overrides.metronomeSound !== null;
+         step.overrides.metronomeSound !== null ||
+         step.overrides.chordAudio !== null;
 }
 
 /**
@@ -73,6 +86,14 @@ export function countNonDefaultSettings(settings) {
   if (settings.accentPattern !== 'standard') count++;
   if (settings.swingRatio !== 0.67) count++;
   if (settings.metronomeSound.type !== 'beep' || settings.metronomeSound.subdivision !== 'quarter') count++;
+
+  // Check chordAudio only if it exists (backward compatibility)
+  if (settings.chordAudio) {
+    if (settings.chordAudio.enabled !== true ||
+        settings.chordAudio.volume !== 0.25 ||
+        settings.chordAudio.duration !== 0.8 ||
+        settings.chordAudio.waveform !== 'sine') count++;
+  }
 
   return count;
 }


### PR DESCRIPTION
## Summary
- Fix metronome timing synchronization during step transitions (no more double-click on beat 1)
- Chord audio now plays continuously for entire step duration instead of pulsing
- Add ability to enable chord audio on scale-type steps via overrides
- Add per-step chord audio override controls in advanced settings
- Improve metronome stability using ref-based scheduler to prevent timing resets

## Test plan
- [x] Test metronome timing across step transitions - smooth, no double-clicks
- [x] Test chord audio plays continuously for step duration
- [x] Test chord audio can be enabled on scale steps
- [x] Test per-step chord audio overrides work correctly
- [x] Verify chord audio settings (volume, waveform, enable/disable) work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)