### PR TITLE
Release v0.0.10: Display enharmonic equivalents in root note dropdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { NOTES } from '../../data/notes';
+import { NOTES, getNoteDisplayName } from '../../data/notes';
 import { TUNINGS, getTuningOptions } from '../../data/tunings';
 import { getScaleOptions } from '../../data/scales';
 import { getChordOptions } from '../../data/chords';
@@ -120,7 +120,7 @@ function Controls({
             onChange={(e) => setRootNote(e.target.value)}
           >
             {NOTES.map(note => (
-              <option key={note} value={note}>{note}</option>
+              <option key={note} value={note}>{getNoteDisplayName(note)}</option>
             ))}
           </select>
         </div>

--- a/src/components/Jam/SequenceStep.jsx
+++ b/src/components/Jam/SequenceStep.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { NOTES } from '../../data/notes';
+import { NOTES, getNoteDisplayName } from '../../data/notes';
 import { getScaleOptions } from '../../data/scales';
 import { getChordOptions } from '../../data/chords';
 import { TIME_SIGNATURES, hasOverrides, resolveStepSettings } from '../../utils/jamSettings';
@@ -76,7 +76,7 @@ function SequenceStep({ step, onChange, onDelete, isActive, index, onPlayChord, 
           className="root-select"
         >
           {NOTES.map(note => (
-            <option key={note} value={note}>{note}</option>
+            <option key={note} value={note}>{getNoteDisplayName(note)}</option>
           ))}
         </select>
 

--- a/src/data/notes.js
+++ b/src/data/notes.js
@@ -10,6 +10,16 @@ export const ENHARMONIC = {
   'A#': 'Bb'
 };
 
+// Get display name for dropdown (shows enharmonic equivalents)
+export function getNoteDisplayName(note) {
+  if (ENHARMONIC[note]) {
+    // Replace # with ♯ and add flat equivalent with ♭
+    return note.replace('#', '♯') + '/' + ENHARMONIC[note].replace('b', '♭');
+  }
+  // Natural notes remain unchanged
+  return note;
+}
+
 // Get note index (0-11)
 export function getNoteIndex(note) {
   const normalized = note.replace('b', '#');


### PR DESCRIPTION
Enhanced root note selection dropdowns to show both sharp and flat notation using proper musical symbols, improving clarity and reducing ambiguity.

**Changes:**
- Added `getNoteDisplayName()` helper function in notes.js
- Updated Learn mode root note dropdown (Controls.jsx)
- Updated Jam mode root note dropdown (SequenceStep.jsx)

**Display Format:**
- Natural notes: C, D, E, F, G, A, B (unchanged)
- Accidentals: C♯/D♭, D♯/E♭, F♯/G♭, G♯/A♭, A♯/B♭ (with proper Unicode symbols)

**Technical Details:**
- Uses proper Unicode musical symbols (♯ U+266F, ♭ U+266D)
- Internal values remain as sharps (e.g., 'C#') - no breaking changes
- All calculations, state management, and presets continue to work
- Display-only change affecting dropdown options

**Benefits:**
- Eliminates ambiguity in note selection
- Professional appearance with proper musical notation
- Better user experience for musicians familiar with both notations

🤖 Generated with [Claude Code](https://claude.com/claude-code)