### PR TITLE
Release v0.0.11: Add metronome volume control to Jam mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Guitar Theory Lab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.11] - 2026-01-03
+
+### Added
+- Metronome volume control in Jam mode Global Settings
+  - New volume slider (0-100%) in Metronome Sound section
+  - Default volume set to 50% for balanced sound levels
+  - Volume control works with all sound types (beep, click, woodblock)
+  - Volume control works with all subdivisions (quarter, eighth, triplet)
+  - Maintains accent pattern behavior while scaling overall volume
+  - Updated src/utils/jamSettings.js to include volume property in DEFAULT_GLOBAL_SETTINGS
+  - Updated src/utils/metronomeSounds.js to accept and apply volume parameter to all sound generators
+  - Updated src/components/Jam/useMetronome.js to pass volume from settings to sound generator
+  - Updated src/components/Jam/GlobalSettings.jsx to add volume slider UI control
+  - Backward compatible with saved presets (defaults to 50% if volume property missing)
+  - Reset to Defaults button includes metronome volume
+
 ## [0.0.7] - 2026-01-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Jam/GlobalSettings.jsx
+++ b/src/components/Jam/GlobalSettings.jsx
@@ -43,9 +43,13 @@ function GlobalSettings({ settings, onSettingsChange }) {
     localStorage.setItem('globalSettings_chord_collapsed', !chordAudioExpanded);
   }, [chordAudioExpanded]);
 
-  // Ensure chordAudio exists with defaults (for backward compatibility)
+  // Ensure chordAudio and metronomeSound.volume exist with defaults (for backward compatibility)
   const safeSettings = {
     ...settings,
+    metronomeSound: {
+      ...settings.metronomeSound,
+      volume: settings.metronomeSound?.volume ?? 0.5
+    },
     chordAudio: settings.chordAudio || {
       enabled: true,
       volume: 0.25,
@@ -285,6 +289,18 @@ function GlobalSettings({ settings, onSettingsChange }) {
                   <option value="triplet">Triplets</option>
                 </select>
               </div>
+              <div className="control-row">
+                <label>Volume: {(safeSettings.metronomeSound.volume * 100).toFixed(0)}%</label>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  value={safeSettings.metronomeSound.volume}
+                  onChange={(e) => updateMetronomeSound('volume', parseFloat(e.target.value))}
+                  className="volume-slider"
+                />
+              </div>
             </div>
             )}
           </div>
@@ -365,7 +381,7 @@ function GlobalSettings({ settings, onSettingsChange }) {
                   accentPattern: 'standard',
                   customAccents: [true, false, false, false],
                   swingRatio: 0.67,
-                  metronomeSound: { type: 'beep', subdivision: 'quarter' },
+                  metronomeSound: { type: 'beep', subdivision: 'quarter', volume: 0.5 },
                   chordAudio: { enabled: true, volume: 0.25, duration: 0.8, waveform: 'sine' }
                 });
               }}

--- a/src/components/Jam/useMetronome.js
+++ b/src/components/Jam/useMetronome.js
@@ -26,8 +26,9 @@ export function useMetronome(bpm, onBeat, isPlaying, metronomeEnabled, effective
     const ctx = getAudioContext();
     const isDownbeat = beatInMeasure === 0;
     const soundType = effectiveSettings.metronomeSound.type;
+    const volume = effectiveSettings.metronomeSound.volume || 0.5;
 
-    playMetronomeSound(ctx, soundType, time, accentStrength, isDownbeat);
+    playMetronomeSound(ctx, soundType, time, accentStrength, isDownbeat, volume);
   }, [getAudioContext, metronomeEnabled, effectiveSettings]);
 
   // Schedule beats ahead of time for accuracy

--- a/src/utils/jamSettings.js
+++ b/src/utils/jamSettings.js
@@ -9,7 +9,8 @@ export const DEFAULT_GLOBAL_SETTINGS = {
   swingRatio: 0.67, // 0.5 = straight eighths, 0.67 = swing/triplet feel
   metronomeSound: {
     type: 'beep', // 'beep', 'click', 'woodblock'
-    subdivision: 'quarter' // 'quarter', 'eighth', 'triplet'
+    subdivision: 'quarter', // 'quarter', 'eighth', 'triplet'
+    volume: 0.5 // Volume level (0.0-1.0)
   },
   chordAudio: {
     enabled: true, // Enable/disable chord playback
@@ -85,7 +86,9 @@ export function countNonDefaultSettings(settings) {
   if (settings.timeSignature.numerator !== 4 || settings.timeSignature.denominator !== 4) count++;
   if (settings.accentPattern !== 'standard') count++;
   if (settings.swingRatio !== 0.67) count++;
-  if (settings.metronomeSound.type !== 'beep' || settings.metronomeSound.subdivision !== 'quarter') count++;
+  if (settings.metronomeSound.type !== 'beep' ||
+      settings.metronomeSound.subdivision !== 'quarter' ||
+      settings.metronomeSound.volume !== 0.5) count++;
 
   // Check chordAudio only if it exists (backward compatibility)
   if (settings.chordAudio) {

--- a/src/utils/metronomeSounds.js
+++ b/src/utils/metronomeSounds.js
@@ -9,8 +9,9 @@
  * @param {number} time - Scheduled play time
  * @param {number} accent - Accent strength 0.0-1.0
  * @param {boolean} isDownbeat - Whether this is the downbeat
+ * @param {number} volumeMultiplier - Volume multiplier 0.0-1.0
  */
-export function generateBeep(ctx, time, accent, isDownbeat) {
+export function generateBeep(ctx, time, accent, isDownbeat, volumeMultiplier = 1.0) {
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();
 
@@ -22,8 +23,8 @@ export function generateBeep(ctx, time, accent, isDownbeat) {
   osc.frequency.value = baseFreq * (1 + accent * 0.2);
   osc.type = 'sine';
 
-  // Adjust volume based on accent strength
-  const volume = 0.1 + (accent * 0.25);
+  // Adjust volume based on accent strength and volume multiplier
+  const volume = (0.1 + (accent * 0.25)) * volumeMultiplier;
   gain.gain.setValueAtTime(volume, time);
   gain.gain.exponentialRampToValueAtTime(0.001, time + 0.05);
 
@@ -37,8 +38,9 @@ export function generateBeep(ctx, time, accent, isDownbeat) {
  * @param {number} time - Scheduled play time
  * @param {number} accent - Accent strength 0.0-1.0
  * @param {boolean} isDownbeat - Whether this is the downbeat
+ * @param {number} volumeMultiplier - Volume multiplier 0.0-1.0
  */
-export function generateClick(ctx, time, accent, isDownbeat) {
+export function generateClick(ctx, time, accent, isDownbeat, volumeMultiplier = 1.0) {
   // Create a short noise buffer
   const bufferSize = ctx.sampleRate * 0.02; // 20ms
   const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
@@ -62,8 +64,8 @@ export function generateClick(ctx, time, accent, isDownbeat) {
   filter.connect(gain);
   gain.connect(ctx.destination);
 
-  // Adjust volume based on accent
-  const volume = 0.15 + (accent * 0.3);
+  // Adjust volume based on accent and volume multiplier
+  const volume = (0.15 + (accent * 0.3)) * volumeMultiplier;
   gain.gain.setValueAtTime(volume, time);
   gain.gain.exponentialRampToValueAtTime(0.001, time + 0.02);
 
@@ -77,8 +79,9 @@ export function generateClick(ctx, time, accent, isDownbeat) {
  * @param {number} time - Scheduled play time
  * @param {number} accent - Accent strength 0.0-1.0
  * @param {boolean} isDownbeat - Whether this is the downbeat
+ * @param {number} volumeMultiplier - Volume multiplier 0.0-1.0
  */
-export function generateWoodblock(ctx, time, accent, isDownbeat) {
+export function generateWoodblock(ctx, time, accent, isDownbeat, volumeMultiplier = 1.0) {
   // Create multiple oscillators for a more complex tone
   const frequencies = isDownbeat ? [480, 720, 1100] : [600, 900, 1350];
 
@@ -92,8 +95,8 @@ export function generateWoodblock(ctx, time, accent, isDownbeat) {
     osc.frequency.value = freq;
     osc.type = 'square';
 
-    // Volume decreases for higher partials
-    const partialVolume = (0.2 / (index + 1)) * (0.5 + accent * 0.5);
+    // Volume decreases for higher partials, scaled by volume multiplier
+    const partialVolume = ((0.2 / (index + 1)) * (0.5 + accent * 0.5)) * volumeMultiplier;
     gain.gain.setValueAtTime(partialVolume, time);
     gain.gain.exponentialRampToValueAtTime(0.001, time + 0.03);
 
@@ -118,15 +121,16 @@ export const SOUND_GENERATORS = {
  * @param {number} time - Scheduled play time
  * @param {number} accent - Accent strength 0.0-1.0
  * @param {boolean} isDownbeat - Whether this is the downbeat
+ * @param {number} volume - Volume level 0.0-1.0
  */
-export function playMetronomeSound(ctx, soundType, time, accent, isDownbeat) {
+export function playMetronomeSound(ctx, soundType, time, accent, isDownbeat, volume = 1.0) {
   const generator = SOUND_GENERATORS[soundType];
 
   if (!generator) {
     console.warn(`Unknown sound type: ${soundType}, using beep`);
-    generateBeep(ctx, time, accent, isDownbeat);
+    generateBeep(ctx, time, accent, isDownbeat, volume);
     return;
   }
 
-  generator(ctx, time, accent, isDownbeat);
+  generator(ctx, time, accent, isDownbeat, volume);
 }


### PR DESCRIPTION
Added a global volume control slider for the metronome in Jam mode's Global Settings panel. Users can now adjust metronome volume from 0% to 100%, with a default of 50%.

- New volume slider (0-100%) in Metronome Sound section
- Default volume set to 50% for balanced sound levels
- Volume control works with all sound types (beep, click, woodblock)
- Volume control works with all subdivisions (quarter, eighth, triplet)
- Maintains accent pattern behavior while scaling overall volume
- Backward compatible with saved presets (defaults to 50% if volume property missing)

Updated files:
- src/utils/jamSettings.js: Added volume property to DEFAULT_GLOBAL_SETTINGS
- src/utils/metronomeSounds.js: Added volume parameter to all sound generators
- src/components/Jam/useMetronome.js: Pass volume from settings to sound generator
- src/components/Jam/GlobalSettings.jsx: Added volume slider UI control
- package.json: Updated version to 0.0.11
- CHANGELOG.md: Documented changes for v0.0.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)