### PR TITLE
Release v0.0.17: Add diagonal neck traversal path feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to Guitar Theory Lab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.17] - 2026-01-03
+
+### Added
+- Learn mode: Neck traversal path feature for practice visualization (Issue #25)
+  - Added "Path Mode" toggle in Controls to enable/disable diagonal path visualization
+  - Path shows optimal route for playing scales/chords up and down the neck
+  - Diagonal path algorithm creates ascending or descending patterns across strings
+  - Direction toggle with "↗ Ascending" and "↙ Descending" buttons
+  - Ascending mode: starts at low frets, climbs ~2 frets per string toward body
+  - Descending mode: starts at high frets, descends ~2 frets per string toward nut
+  - Range slider (±2 to ±8 frets) controls path width for narrow or wide patterns
+  - Notes on path remain bright (green for scales, yellow for chords, red for root)
+  - Off-path scale/chord notes dimmed to 30% opacity for visual distinction
+  - Added calculateNeckTraversalPath() function in src/utils/musicTheory.js
+  - Implemented greedy nearest-neighbor algorithm with directional preference
+  - Path expands based on fret range window to include nearby alternate positions
+  - Works with all scales and chords in both Learn Mode scale and chord views
+  - Added pathModeEnabled, fretRangeWidth, and pathDirection state to src/App.jsx
+  - Updated src/components/Controls/Controls.jsx with path mode UI controls
+  - Updated src/components/Fretboard/Fretboard.jsx with path rendering logic
+  - Added .dimmed CSS class in src/components/Fretboard/Fretboard.css
+  - Added path control styling in src/components/Controls/Controls.css
+  - Path respects tab view (inverted strings) with proper string index mapping
+  - Path respects interval filtering - only includes filtered notes
+  - Compatible with all tunings (standard, bass, alternate tunings)
+  - Handles edge cases: sparse scales, chromatic scale, varying fret counts
+
 ## [0.0.16] - 2026-01-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ import Practice from './components/Practice/Practice';
 import Jam from './components/Jam/Jam';
 import Footer from './components/Footer/Footer';
 import { TUNINGS, DEFAULT_TUNING } from './data/tunings';
-import { getScaleNotes, getChordNotes } from './utils/musicTheory';
+import { getScaleNotes, getChordNotes, calculateNeckTraversalPath } from './utils/musicTheory';
 import './App.css';
 
 function App() {
@@ -25,6 +25,11 @@ function App() {
   const [showIntervals, setShowIntervals] = useState(false);
   const [tabView, setTabView] = useState(false);
   const [fretCount, setFretCount] = useState(22);
+
+  // Neck traversal path state
+  const [pathModeEnabled, setPathModeEnabled] = useState(false);
+  const [fretRangeWidth, setFretRangeWidth] = useState(4);
+  const [pathDirection, setPathDirection] = useState('ascending'); // 'ascending' or 'descending'
 
   // Filter state for intervals/notes
   const [filteredIntervals, setFilteredIntervals] = useState({
@@ -83,6 +88,21 @@ function App() {
     }
   }, [rootNote, mode, scaleType, chordType]);
 
+  // Compute traversal path when enabled
+  const traversalPath = useMemo(() => {
+    if (!pathModeEnabled || !highlightedNotes.length) return [];
+
+    return calculateNeckTraversalPath(
+      tuning,
+      highlightedNotes,
+      rootNote,
+      fretCount,
+      fretRangeWidth,
+      tabView,
+      pathDirection
+    );
+  }, [pathModeEnabled, tuning, highlightedNotes, rootNote, fretCount, fretRangeWidth, tabView, pathDirection]);
+
   return (
     <div className="app">
       <header className="app-header">
@@ -133,6 +153,12 @@ function App() {
               setFilteredIntervals={setFilteredIntervals}
               fretCount={fretCount}
               setFretCount={setFretCount}
+              pathModeEnabled={pathModeEnabled}
+              setPathModeEnabled={setPathModeEnabled}
+              fretRangeWidth={fretRangeWidth}
+              setFretRangeWidth={setFretRangeWidth}
+              pathDirection={pathDirection}
+              setPathDirection={setPathDirection}
             />
 
             <Reference
@@ -151,6 +177,8 @@ function App() {
               tabView={tabView}
               filteredIntervals={filteredIntervals}
               fretCount={fretCount}
+              pathModeEnabled={pathModeEnabled}
+              traversalPath={traversalPath}
             />
           </>
         ) : activeTab === 'practice' ? (

--- a/src/components/Controls/Controls.css
+++ b/src/components/Controls/Controls.css
@@ -294,3 +294,90 @@
     left: 0;
   }
 }
+
+/* Path Mode Controls */
+.path-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.path-direction-toggle {
+  display: flex;
+  gap: 4px;
+  margin-left: 20px;
+}
+
+.path-direction-toggle button {
+  padding: 4px 10px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--bg-tertiary);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85em;
+  transition: all 0.2s;
+}
+
+.path-direction-toggle button:hover {
+  background: var(--bg-primary);
+  border-color: var(--accent);
+}
+
+.path-direction-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.path-range-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 20px;
+  padding-left: 8px;
+  border-left: 2px solid var(--accent);
+}
+
+.path-range-slider {
+  width: 100px;
+  height: 5px;
+  border-radius: 3px;
+  background: var(--bg-tertiary);
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+}
+
+.path-range-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.path-range-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+  box-shadow: 0 0 6px var(--accent);
+}
+
+.path-range-slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s;
+}
+
+.path-range-slider::-moz-range-thumb:hover {
+  transform: scale(1.15);
+  box-shadow: 0 0 6px var(--accent);
+}

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -38,7 +38,13 @@ function Controls({
   filteredIntervals,
   setFilteredIntervals,
   fretCount,
-  setFretCount
+  setFretCount,
+  pathModeEnabled,
+  setPathModeEnabled,
+  fretRangeWidth,
+  setFretRangeWidth,
+  pathDirection,
+  setPathDirection
 }) {
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);
   const dropdownRef = useRef(null);
@@ -200,6 +206,48 @@ function Controls({
             onChange={(e) => setFretCount(parseInt(e.target.value))}
             className="fret-slider"
           />
+        </div>
+
+        <div className="control-group path-control-group">
+          <label>
+            <input
+              type="checkbox"
+              checked={pathModeEnabled}
+              onChange={(e) => setPathModeEnabled(e.target.checked)}
+            />
+            Path Mode
+          </label>
+
+          {pathModeEnabled && (
+            <>
+              <div className="path-direction-toggle">
+                <button
+                  className={pathDirection === 'ascending' ? 'active' : ''}
+                  onClick={() => setPathDirection('ascending')}
+                >
+                  ↗ Ascending
+                </button>
+                <button
+                  className={pathDirection === 'descending' ? 'active' : ''}
+                  onClick={() => setPathDirection('descending')}
+                >
+                  ↙ Descending
+                </button>
+              </div>
+              <div className="path-range-control">
+                <label>Range: ±{fretRangeWidth} frets</label>
+                <input
+                  type="range"
+                  min="2"
+                  max="8"
+                  step="1"
+                  value={fretRangeWidth}
+                  onChange={(e) => setFretRangeWidth(parseInt(e.target.value))}
+                  className="path-range-slider"
+                />
+              </div>
+            </>
+          )}
         </div>
       </div>
 

--- a/src/components/Fretboard/Fretboard.css
+++ b/src/components/Fretboard/Fretboard.css
@@ -109,6 +109,18 @@
   transform: scale(1.1);
 }
 
+.note-dot.dimmed {
+  background: var(--note-inactive);
+  color: var(--text-secondary);
+  opacity: 0.3;
+  box-shadow: none;
+}
+
+.note-dot.dimmed:hover {
+  opacity: 0.5;
+  transform: scale(1.05);
+}
+
 .note-dot.highlighted {
   background: var(--note-scale);
   color: #000;

--- a/src/components/Fretboard/Fretboard.jsx
+++ b/src/components/Fretboard/Fretboard.jsx
@@ -16,7 +16,9 @@ function Fretboard({
   onFretClick = null,
   revealedFrets = [],
   filteredIntervals = null,
-  fretCount = 22
+  fretCount = 22,
+  pathModeEnabled = false,
+  traversalPath = []
 }) {
   const fretboardData = useMemo(() => {
     const data = tuning.map((openNote, stringIndex) => {
@@ -65,6 +67,26 @@ function Fretboard({
       if (!filteredIntervals[interval]) {
         return 'inactive';
       }
+    }
+
+    // Path mode logic
+    if (pathModeEnabled && traversalPath.length > 0) {
+      // Get the actual stringIndex from tuning (accounting for tabView)
+      const actualStringIndex = tabView ? (tuning.length - 1 - stringIdx) : stringIdx;
+
+      const isInPath = traversalPath.some(
+        p => p.stringIndex === actualStringIndex && p.fret === fret && p.note === note
+      );
+
+      if (!isInPath && highlightedNotes.includes(note)) {
+        // Note is in scale/chord but NOT in path - dim it
+        return 'dimmed';
+      }
+      if (!isInPath) {
+        // Note is not in scale/chord at all
+        return 'inactive';
+      }
+      // Note IS in path - apply normal coloring below
     }
 
     if (note === rootNote) return 'root';


### PR DESCRIPTION
This release implements Issue #25 - a path mode visualization for Learn Mode that helps guitarists practice scales and chords by showing optimal diagonal routes up and down the fretboard.

Key features:
- Path Mode toggle with ascending/descending direction control
- Diagonal path algorithm (~2 frets per string)
- Adjustable width range (±2 to ±8 frets)
- Visual distinction: path notes bright, off-path dimmed
- Works with all scales, chords, tunings, and view options

🤖 Generated with [Claude Code](https://claude.com/claude-code)