### PR TITLE
Release v0.0.18: Add Learn More panel to Name That Chord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Guitar Theory Lab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.18] - 2026-01-04
+
+### Added
+- Practice mode: "Learn More" panel for Name That Chord quiz
+  - New collapsible panel showing music theory context for each chord type
+  - "Learn more" checkbox toggle in hint options (hidden by default)
+  - Panel displays four educational sections:
+    - **Common Uses**: Genres, musical contexts, and famous artists who use the chord
+    - **Tension & Resolution**: How the chord creates or resolves musical tension
+    - **Related Chords**: Other chord types that share notes or pair well
+    - **Typical Progressions**: Common chord progressions featuring this chord
+  - Added `theoryContext` property to all 16 chord definitions in src/data/chords.js
+  - Purple-tinted panel styling to distinguish from green strategy hints
+  - Comprehensive theory content covering triads, suspended, 7th, and 9th chords
+  - Educational content includes genre associations (jazz, rock, funk, R&B, etc.)
+  - Added CSS styles for `.learn-more-panel` and `.theory-section` in Practice.css
+
 ## [0.0.17] - 2026-01-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guitar-theory-lab",
-  "version": "0.0.8",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guitar-theory-lab",
-      "version": "0.0.8",
+      "version": "0.0.17",
       "dependencies": {
         "react": "^19.2.0",
         "react-dom": "^19.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Practice/Practice.css
+++ b/src/components/Practice/Practice.css
@@ -63,6 +63,57 @@
   text-align: left;
 }
 
+.learn-more-panel {
+  background: rgba(138, 120, 190, 0.1);
+  border-left: 3px solid #8a78be;
+  padding: 15px 20px;
+  margin: 0 auto 20px;
+  border-radius: 6px;
+  color: var(--text-primary);
+  max-width: 600px;
+  text-align: left;
+}
+
+.learn-more-panel h4 {
+  margin: 0 0 15px 0;
+  color: #a99cd4;
+  font-size: 1.1em;
+}
+
+.theory-section {
+  margin-bottom: 12px;
+}
+
+.theory-section:last-child {
+  margin-bottom: 0;
+}
+
+.theory-section strong {
+  color: #a99cd4;
+  font-size: 0.9em;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.theory-section p {
+  margin: 0;
+  font-size: 0.9em;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.theory-section ul {
+  margin: 4px 0 0 0;
+  padding-left: 20px;
+  font-size: 0.9em;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.theory-section li {
+  margin-bottom: 2px;
+}
+
 .score {
   display: flex;
   gap: 15px;

--- a/src/components/Practice/Practice.jsx
+++ b/src/components/Practice/Practice.jsx
@@ -12,6 +12,7 @@ function Practice({ tuning, onReset, onHighlightChange, showIntervals, setShowIn
   const [score, setScore] = useState({ correct: 0, incorrect: 0 });
   const [showRootHint, setShowRootHint] = useState(false);
   const [showStrategyHint, setShowStrategyHint] = useState(false);
+  const [showLearnMore, setShowLearnMore] = useState(false);
 
   // Generate string names dynamically based on tuning
   const getStringName = (idx) => {
@@ -245,6 +246,14 @@ function Practice({ tuning, onReset, onHighlightChange, showIntervals, setShowIn
             />
             Show intervals
           </label>
+          <label className="hint-toggle">
+            <input
+              type="checkbox"
+              checked={showLearnMore}
+              onChange={(e) => setShowLearnMore(e.target.checked)}
+            />
+            Learn more
+          </label>
         </div>
       )}
 
@@ -316,6 +325,31 @@ function Practice({ tuning, onReset, onHighlightChange, showIntervals, setShowIn
             {showStrategyHint && question.chordType && (
               <div className="strategy-hint">
                 💡 {getChordStrategyHint(question.chordType)}
+              </div>
+            )}
+            {showLearnMore && question.chordType && CHORDS[question.chordType]?.theoryContext && (
+              <div className="learn-more-panel">
+                <h4>About {CHORDS[question.chordType].name} Chords</h4>
+                <div className="theory-section">
+                  <strong>Common Uses:</strong>
+                  <p>{CHORDS[question.chordType].theoryContext.commonUses}</p>
+                </div>
+                <div className="theory-section">
+                  <strong>Tension & Resolution:</strong>
+                  <p>{CHORDS[question.chordType].theoryContext.tensionResolution}</p>
+                </div>
+                <div className="theory-section">
+                  <strong>Related Chords:</strong>
+                  <p>{CHORDS[question.chordType].theoryContext.relatedChords.map(c => CHORDS[c]?.name || c).join(', ')}</p>
+                </div>
+                <div className="theory-section">
+                  <strong>Typical Progressions:</strong>
+                  <ul>
+                    {CHORDS[question.chordType].theoryContext.typicalProgressions.map((prog, idx) => (
+                      <li key={idx}>{prog}</li>
+                    ))}
+                  </ul>
+                </div>
               </div>
             )}
             <div className="answer-options">

--- a/src/data/chords.js
+++ b/src/data/chords.js
@@ -5,97 +5,193 @@ export const CHORDS = {
     name: 'Major',
     intervals: [0, 4, 7],
     formula: '1-3-5',
-    description: 'Happy, bright sound'
+    description: 'Happy, bright sound',
+    theoryContext: {
+      commonUses: 'The foundation of Western music. Used as the "home" chord (I) in pop, rock, country, and folk. Creates feelings of happiness and resolution.',
+      tensionResolution: 'Stable and resolved. The chord everything else wants to come back to.',
+      relatedChords: ['minor', 'sus4', 'maj7', 'add9'],
+      typicalProgressions: ['I-IV-V (most common in rock/pop)', 'I-V-vi-IV (pop anthem progression)']
+    }
   },
   minor: {
     name: 'Minor',
     intervals: [0, 3, 7],
     formula: '1-b3-5',
-    description: 'Sad, dark sound'
+    description: 'Sad, dark sound',
+    theoryContext: {
+      commonUses: 'Essential for emotional depth. The vi chord in major keys, or the i chord in minor keys. Common in ballads, rock, R&B, and any music expressing sadness or introspection.',
+      tensionResolution: 'Moderate tension with a melancholic quality. Stable in minor keys, creates contrast in major keys.',
+      relatedChords: ['major', 'diminished', 'min7', 'min9'],
+      typicalProgressions: ['i-iv-v (natural minor)', 'vi-IV-I-V (pop progression from minor perspective)']
+    }
   },
   diminished: {
     name: 'Diminished',
     intervals: [0, 3, 6],
     formula: '1-b3-b5',
-    description: 'Tense, unstable sound'
+    description: 'Tense, unstable sound',
+    theoryContext: {
+      commonUses: 'A passing chord that creates drama. Common in classical, jazz, and musical theater. Often used as the vii° chord leading to the I chord.',
+      tensionResolution: 'High tension that demands resolution. Naturally wants to resolve up a half-step to a major or minor chord.',
+      relatedChords: ['dim7', 'min7b5', 'minor'],
+      typicalProgressions: ['vii°-I (leading tone resolution)', 'Used as chromatic passing chord between IV and V']
+    }
   },
   augmented: {
     name: 'Augmented',
     intervals: [0, 4, 8],
     formula: '1-3-#5',
-    description: 'Bright, unsettled sound'
+    description: 'Bright, unsettled sound',
+    theoryContext: {
+      commonUses: 'Creates dreamlike, mysterious moments. Used in film scores, progressive rock, and jazz. Often appears in Beatles songs and classical music for dramatic effect.',
+      tensionResolution: 'Unstable and floating. Can resolve to either major or minor, creating ambiguity. The raised 5th wants to continue rising.',
+      relatedChords: ['major', 'dom7', 'maj7'],
+      typicalProgressions: ['I-I+-vi (chromatic bass line)', 'V+-I (enhanced dominant resolution)']
+    }
   },
   sus2: {
     name: 'Suspended 2nd',
     intervals: [0, 2, 7],
     formula: '1-2-5',
-    description: 'Open, unresolved sound'
+    description: 'Open, unresolved sound',
+    theoryContext: {
+      commonUses: 'Creates an open, airy feel. Popular in ambient, folk, indie, and worship music. The Police and U2 use sus2 chords extensively.',
+      tensionResolution: 'Suspended between major and minor - neither happy nor sad. Can resolve to major or minor, or stand alone for an ambiguous mood.',
+      relatedChords: ['major', 'sus4', 'add9'],
+      typicalProgressions: ['Isus2-I (subtle resolution)', 'Often used as a color chord without resolution']
+    }
   },
   sus4: {
     name: 'Suspended 4th',
     intervals: [0, 5, 7],
     formula: '1-4-5',
-    description: 'Tension waiting to resolve'
+    description: 'Tension waiting to resolve',
+    theoryContext: {
+      commonUses: 'Classic rock and pop anticipation chord. Creates tension before resolving to major. Essential in songs like "Pinball Wizard" and countless worship songs.',
+      tensionResolution: 'The 4th degree pulls down to the 3rd, creating anticipation. More urgent tension than sus2. Almost always resolves to major.',
+      relatedChords: ['major', 'sus2', 'dom7sus4'],
+      typicalProgressions: ['Isus4-I (classic resolution)', 'Vsus4-V-I (extended dominant resolution)']
+    }
   },
   dom7: {
     name: 'Dominant 7th',
     intervals: [0, 4, 7, 10],
     formula: '1-3-5-b7',
-    description: 'Blues/jazz essential'
+    description: 'Blues/jazz essential',
+    theoryContext: {
+      commonUses: 'The backbone of blues, jazz, and rock. As the V7 chord, it creates the strongest pull back to the I chord. Every 12-bar blues uses dominant 7ths throughout.',
+      tensionResolution: 'Strong tension from the tritone between the 3rd and b7th. This interval desperately wants to resolve, making V7-I the most powerful resolution in music.',
+      relatedChords: ['major', 'maj7', 'dom9', 'min7'],
+      typicalProgressions: ['V7-I (strongest resolution)', 'I7-IV7-V7 (12-bar blues)', 'ii-V7-I (jazz standard)']
+    }
   },
   maj7: {
     name: 'Major 7th',
     intervals: [0, 4, 7, 11],
     formula: '1-3-5-7',
-    description: 'Smooth, jazzy sound'
+    description: 'Smooth, jazzy sound',
+    theoryContext: {
+      commonUses: 'The sophisticated "jazz" chord. Common as the I chord in jazz, R&B, neo-soul, and bossa nova. Adds warmth and complexity to any major chord.',
+      tensionResolution: 'Stable but colorful. The major 7th adds a dreamy quality without creating urgency to resolve. Can function as a resting point.',
+      relatedChords: ['major', 'dom7', 'maj9', 'add9'],
+      typicalProgressions: ['Imaj7-IVmaj7 (smooth jazz vamp)', 'IVmaj7-V7-Imaj7 (jazz cadence)']
+    }
   },
   min7: {
     name: 'Minor 7th',
     intervals: [0, 3, 7, 10],
     formula: '1-b3-5-b7',
-    description: 'Mellow, soulful sound'
+    description: 'Mellow, soulful sound',
+    theoryContext: {
+      commonUses: 'The workhorse of jazz and soul. Functions as the ii chord in major keys (ii-V-I). Essential in R&B, neo-soul, and any music needing smooth, mellow color.',
+      tensionResolution: 'Gentle tension that flows naturally to dominant chords. More relaxed than plain minor. Creates movement without urgency.',
+      relatedChords: ['minor', 'dom7', 'min9', 'maj7'],
+      typicalProgressions: ['ii7-V7-Imaj7 (the jazz progression)', 'i7-iv7 (minor groove)']
+    }
   },
   dim7: {
     name: 'Diminished 7th',
     intervals: [0, 3, 6, 9],
     formula: '1-b3-b5-bb7',
-    description: 'Symmetrical, mysterious'
+    description: 'Symmetrical, mysterious',
+    theoryContext: {
+      commonUses: 'Dramatic tension in classical, jazz, and film scores. Symmetrical structure means it can resolve in four different directions. Common in silent film music and horror.',
+      tensionResolution: 'Maximum tension. The fully diminished sound is unstable from every angle. Can resolve up or down by half-step to major or minor chords.',
+      relatedChords: ['diminished', 'min7b5', 'dom7b9'],
+      typicalProgressions: ['vii°7-I (dramatic resolution)', 'Used as pivot chord for modulation']
+    }
   },
   min7b5: {
     name: 'Half-Diminished (m7b5)',
     intervals: [0, 3, 6, 10],
     formula: '1-b3-b5-b7',
-    description: 'Jazz minor ii chord'
+    description: 'Jazz minor ii chord',
+    theoryContext: {
+      commonUses: 'Essential jazz chord. The ii chord in minor keys, setting up the V7 to i resolution. Also appears naturally as vii in major keys. Common in jazz standards and film noir.',
+      tensionResolution: 'Dark tension that leads beautifully to dominant 7th chords. Less harsh than fully diminished. The "half" means it has a minor 7th instead of diminished 7th.',
+      relatedChords: ['dim7', 'min7', 'dom7'],
+      typicalProgressions: ['ii°7-V7-i (minor ii-V-i)', 'viiø7-I (in major keys)']
+    }
   },
   add9: {
     name: 'Add 9',
     intervals: [0, 4, 7, 14],
     formula: '1-3-5-9',
-    description: 'Major with added 9th'
+    description: 'Major with added 9th',
+    theoryContext: {
+      commonUses: 'Adds sparkle to a basic major chord. Popular in pop, rock, and acoustic music. Oasis and many 90s bands loved this sound. More accessible than full 9th chords.',
+      tensionResolution: 'Stable with added color. The 9th adds interest without changing the chord\'s function. No 7th means less jazz complexity.',
+      relatedChords: ['major', 'maj9', 'sus2'],
+      typicalProgressions: ['Can replace any major chord for added color', 'Iadd9-IVadd9 (shimmery progression)']
+    }
   },
   power: {
     name: 'Power Chord (5)',
     intervals: [0, 7],
     formula: '1-5',
-    description: 'Rock essential, no 3rd'
+    description: 'Rock essential, no 3rd',
+    theoryContext: {
+      commonUses: 'The foundation of rock, metal, and punk. No 3rd means it\'s neither major nor minor - pure power. Works great with distortion because simpler intervals sound cleaner.',
+      tensionResolution: 'Neutral and aggressive. Without the 3rd, there\'s no happy/sad quality - just raw energy. Can substitute for any major or minor chord.',
+      relatedChords: ['major', 'minor', 'sus4'],
+      typicalProgressions: ['I5-IV5-V5 (punk/rock)', 'i5-bVII5-bVI5 (metal)']
+    }
   },
   dom9: {
     name: 'Dominant 9th',
     intervals: [0, 4, 7, 10, 14],
     formula: '1-3-5-b7-9',
-    description: 'Funky, soulful'
+    description: 'Funky, soulful',
+    theoryContext: {
+      commonUses: 'The funk and soul chord. James Brown, Prince, and Stevie Wonder built careers on this sound. Also essential in jazz as an extended V chord.',
+      tensionResolution: 'Funky tension with the dominant pull. The 9th adds richness while the b7 maintains the drive to resolve. Can also groove without resolving in funk contexts.',
+      relatedChords: ['dom7', 'min9', 'dom7sus4'],
+      typicalProgressions: ['V9-I (jazz resolution)', 'I9-IV9 (funk vamp)']
+    }
   },
   maj9: {
     name: 'Major 9th',
     intervals: [0, 4, 7, 11, 14],
     formula: '1-3-5-7-9',
-    description: 'Lush, sophisticated'
+    description: 'Lush, sophisticated',
+    theoryContext: {
+      commonUses: 'The ultimate "pretty" chord. Staple of neo-soul, jazz ballads, and sophisticated pop. D\'Angelo, Erykah Badu, and jazz pianists love this lush sound.',
+      tensionResolution: 'Rich and stable. All the color of maj7 plus the 9th\'s shimmer. Functions as a luxurious tonic chord that doesn\'t need to go anywhere.',
+      relatedChords: ['maj7', 'add9', 'min9'],
+      typicalProgressions: ['Imaj9-IVmaj9 (neo-soul)', 'iim9-V9-Imaj9 (jazz ballad)']
+    }
   },
   min9: {
     name: 'Minor 9th',
     intervals: [0, 3, 7, 10, 14],
     formula: '1-b3-5-b7-9',
-    description: 'Smooth R&B/jazz'
+    description: 'Smooth R&B/jazz',
+    theoryContext: {
+      commonUses: 'The smooth R&B and neo-soul sound. Perfect as the ii chord in jazz or as a tonic in R&B. Common in music by Sade, Maxwell, and contemporary jazz.',
+      tensionResolution: 'Velvety tension. The minor quality plus the 9th creates sophisticated melancholy. Flows beautifully to dominant chords or can vamp on its own.',
+      relatedChords: ['min7', 'maj9', 'dom9'],
+      typicalProgressions: ['iim9-V9-Imaj9 (smooth jazz)', 'im9-IVmaj9 (R&B ballad)']
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- Add "Learn More" panel to Name That Chord practice mode with music theory context
- Panel shows common uses, tension/resolution, related chords, and typical progressions for each chord type
- Hidden by default - users can toggle it on via "Learn more" checkbox
- Purple-tinted styling distinguishes it from the green strategy hint

## Changes
- Added `theoryContext` property to all 16 chord definitions in `src/data/chords.js`
- Added `showLearnMore` state and checkbox toggle in `src/components/Practice/Practice.jsx`
- Added Learn More panel JSX with four educational sections
- Added CSS styles for `.learn-more-panel` and `.theory-section` in `src/components/Practice/Practice.css`

## Test plan
- [ ] Go to Practice mode and select "Name That Chord"
- [ ] Verify "Learn more" checkbox appears in hint options
- [ ] Enable "Learn more" and verify purple panel appears with chord theory info
- [ ] Verify all 16 chord types display correct theory context
- [ ] Verify panel is hidden by default on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)