### PR TITLE
Release v0.0.19: Add toggleable fretboard inlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Guitar Theory Lab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.19] - 2026-01-04
+
+### Added
+- Toggleable fretboard inlays feature
+  - Pearl-style dot inlays appear on the fretboard wood surface at standard positions (3, 5, 7, 9, 12, 15, 17, 19, 21)
+  - Double dots at octave positions (frets 12 and 24)
+  - Global "Show Inlays" toggle in header area, applies to all modes (Learn, Practice, Jam)
+  - Inlays ON by default to help beginners orient on the neck
+  - Added `showInlays` state to src/App.jsx with global toggle UI
+  - Added inlay overlay layer in src/components/Fretboard/Fretboard.jsx
+  - Added pearl gradient styling in src/components/Fretboard/Fretboard.css
+  - Added global settings styling in src/App.css
+  - Inlays render behind strings and note dots using z-index layering
+
 ## [0.0.18] - 2026-01-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.css
+++ b/src/App.css
@@ -53,3 +53,31 @@
   max-width: 1400px;
   margin: 0 auto;
 }
+
+.global-settings {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  padding: 10px 20px;
+  margin: 0 20px 15px;
+}
+
+.setting-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9em;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.setting-toggle:hover {
+  color: var(--text-primary);
+}
+
+.setting-toggle input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,9 @@ function App() {
   const [tabView, setTabView] = useState(false);
   const [fretCount, setFretCount] = useState(22);
 
+  // Global display settings
+  const [showInlays, setShowInlays] = useState(true);
+
   // Neck traversal path state
   const [pathModeEnabled, setPathModeEnabled] = useState(false);
   const [fretRangeWidth, setFretRangeWidth] = useState(4);
@@ -131,6 +134,17 @@ function App() {
         </button>
       </nav>
 
+      <div className="global-settings">
+        <label className="setting-toggle">
+          <input
+            type="checkbox"
+            checked={showInlays}
+            onChange={(e) => setShowInlays(e.target.checked)}
+          />
+          Show Inlays
+        </label>
+      </div>
+
       <main className="main-content">
         {activeTab === 'learn' ? (
           <>
@@ -179,6 +193,7 @@ function App() {
               fretCount={fretCount}
               pathModeEnabled={pathModeEnabled}
               traversalPath={traversalPath}
+              showInlays={showInlays}
             />
           </>
         ) : activeTab === 'practice' ? (
@@ -228,6 +243,7 @@ function App() {
               onFretClick={handleFretClick}
               revealedFrets={revealedFrets}
               fretCount={fretCount}
+              showInlays={showInlays}
             />
           </>
         ) : activeTab === 'jam' ? (
@@ -270,6 +286,7 @@ function App() {
               mode={jamHighlight.mode}
               tabView={tabView}
               fretCount={fretCount}
+              showInlays={showInlays}
             />
           </>
         ) : null}

--- a/src/components/Fretboard/Fretboard.css
+++ b/src/components/Fretboard/Fretboard.css
@@ -12,6 +12,7 @@
   padding: 15px 10px;
   min-width: 1200px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  position: relative;
 }
 
 .string-row {
@@ -199,4 +200,64 @@
   font-size: 0.75em;
   text-align: center;
   width: 100%;
+}
+
+/* Fretboard Inlays - Pearl dot markers */
+.fretboard-inlays {
+  position: absolute;
+  top: 15px;
+  left: 60px;
+  right: 10px;
+  bottom: 60px;
+  display: flex;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.inlay-position {
+  flex: 1;
+  min-width: 45px;
+  max-width: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.inlay-position:first-child {
+  min-width: 55px;
+}
+
+.inlay-dot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.inlay-dot-inner {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(
+    ellipse at 30% 30%,
+    #f5f5f0 0%,
+    #e8e8e0 30%,
+    #d4d4c8 60%,
+    #c0c0b0 100%
+  );
+  box-shadow:
+    inset 0 1px 2px rgba(255, 255, 255, 0.8),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.2),
+    0 1px 3px rgba(0, 0, 0, 0.4);
+  opacity: 0.85;
+}
+
+.inlay-dot.double {
+  gap: 40px;
+}
+
+.inlay-dot.double .inlay-dot-inner {
+  width: 10px;
+  height: 10px;
 }

--- a/src/components/Fretboard/Fretboard.jsx
+++ b/src/components/Fretboard/Fretboard.jsx
@@ -18,7 +18,8 @@ function Fretboard({
   filteredIntervals = null,
   fretCount = 22,
   pathModeEnabled = false,
-  traversalPath = []
+  traversalPath = [],
+  showInlays = true
 }) {
   const fretboardData = useMemo(() => {
     const data = tuning.map((openNote, stringIndex) => {
@@ -160,6 +161,26 @@ function Fretboard({
             </div>
           </div>
         ))}
+        {showInlays && (
+          <div className="fretboard-inlays">
+            {Array.from({ length: fretCount + 1 }, (_, fret) => (
+              <div key={fret} className="inlay-position">
+                {FRET_MARKERS.includes(fret) && (
+                  DOUBLE_MARKERS.includes(fret) ? (
+                    <div className="inlay-dot double">
+                      <div className="inlay-dot-inner" />
+                      <div className="inlay-dot-inner" />
+                    </div>
+                  ) : (
+                    <div className="inlay-dot">
+                      <div className="inlay-dot-inner" />
+                    </div>
+                  )
+                )}
+              </div>
+            ))}
+          </div>
+        )}
         <div className="fret-markers">
           {Array.from({ length: fretCount + 1 }, (_, fret) => (
             <div key={fret} className="fret-marker">


### PR DESCRIPTION
## Summary
- Added toggleable fretboard inlays (pearl-style dots) at standard positions (3, 5, 7, 9, 12, 15, 17, 19, 21)
- Double dots at octave positions (frets 12 and 24)
- Global "Show Inlays" toggle in header area applies to all modes
- Inlays ON by default to help beginners orient on the neck

## Test plan
- [x] Verify inlays appear on fretboard in Learn mode
- [x] Verify inlays appear on fretboard in Practice mode
- [x] Verify inlays appear on fretboard in Jam mode
- [x] Toggle "Show Inlays" off and verify inlays disappear
- [x] Verify double dots appear at frets 12 and 24
- [x] Verify inlays don't interfere with note dot clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)