### PR TITLE
Release v0.0.21: Add chord voicing/position cycling feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to Guitar Theory Lab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.21] - 2026-01-08
+
+### Added
+- Chord voicing/position cycling feature
+  - Toggle between "All Notes" and "Voicing" view when viewing chords
+  - Cycle through playable chord shapes with prev/next arrows and dropdown
+  - New files: src/data/voicings.js (chord voicing data), src/utils/voicingUtils.js (utilities)
+  - New component: src/components/VoicingControls/ for voicing selection UI
+- Predefined voicings for common chords
+  - Open chord shapes: C, G, D, A, E, F major; Am, Em, Dm minor; plus 7th chords
+  - Moveable barre shapes: E-shape and A-shape for major, minor, dom7, min7, maj7
+- Algorithmic voicing generation for chords without predefined shapes
+  - Generates playable positions based on fret span constraints
+  - Fallback for any chord type in any key
+- Learn mode voicing integration
+  - VoicingControls component appears when in chord mode
+  - Shows muted string indicators (X) next to string labels for voicing mode
+  - Dimmed notes show chord tones not in current voicing
+- Jam mode per-step voicing controls
+  - Each chord step has "All" / "Shape" toggle
+  - Prev/next navigation when in Shape mode
+  - Voicing positions passed to fretboard for accurate display
+- Practice mode "Name That Shape" quiz
+  - New quiz type that shows a specific voicing
+  - User identifies the chord (root + type) from the shape
+  - Uses same hint options as "Name That Chord" quiz
+
+### Changed
+- Updated src/App.jsx with voicing state management
+- Updated src/components/Controls/Controls.jsx to integrate VoicingControls
+- Updated src/components/Fretboard/Fretboard.jsx to render voicing positions
+- Updated src/components/Jam/Jam.jsx with voicing support per step
+- Updated src/components/Jam/SequenceStep.jsx with voicing controls UI
+- Updated src/components/Practice/Practice.jsx with shape quiz type
+
 ## [0.0.20] - 2026-01-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -1,6 +1,7 @@
 import { NOTES, getNoteDisplayName } from '../../data/notes';
 import { getScaleOptions } from '../../data/scales';
 import { getChordOptions } from '../../data/chords';
+import VoicingControls from '../VoicingControls/VoicingControls';
 import './Controls.css';
 
 function Controls({
@@ -17,7 +18,12 @@ function Controls({
   fretRangeWidth,
   setFretRangeWidth,
   pathDirection,
-  setPathDirection
+  setPathDirection,
+  voicingMode,
+  setVoicingMode,
+  selectedVoicingIndex,
+  setSelectedVoicingIndex,
+  availableVoicings
 }) {
   const scaleOptions = getScaleOptions();
   const chordOptions = getChordOptions();
@@ -69,19 +75,29 @@ function Controls({
             </select>
           </div>
         ) : (
-          <div className="control-group">
-            <label>Type</label>
-            <select
-              value={chordType}
-              onChange={(e) => setChordType(e.target.value)}
-            >
-              {chordOptions.map(opt => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          </div>
+          <>
+            <div className="control-group">
+              <label>Type</label>
+              <select
+                value={chordType}
+                onChange={(e) => setChordType(e.target.value)}
+              >
+                {chordOptions.map(opt => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <VoicingControls
+              voicingMode={voicingMode}
+              setVoicingMode={setVoicingMode}
+              selectedVoicingIndex={selectedVoicingIndex}
+              setSelectedVoicingIndex={setSelectedVoicingIndex}
+              availableVoicings={availableVoicings}
+            />
+          </>
         )}
 
         <div className="control-group path-control-group">

--- a/src/components/Fretboard/Fretboard.css
+++ b/src/components/Fretboard/Fretboard.css
@@ -50,6 +50,19 @@
   color: var(--text-secondary);
   font-size: 0.9em;
   z-index: 2;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+
+/* Muted string indicator (X) for voicing mode */
+.muted-indicator {
+  color: #ff5252;
+  font-weight: bold;
+  font-size: 0.8em;
+  opacity: 0.9;
 }
 
 .frets-container {

--- a/src/components/Jam/Jam.css
+++ b/src/components/Jam/Jam.css
@@ -591,3 +591,84 @@
 .inline-checkbox span {
   cursor: pointer;
 }
+
+/* Step Voicing Controls */
+.step-voicing-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--bg-tertiary);
+}
+
+.voicing-mode-toggle {
+  display: flex;
+  gap: 0;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.voicing-mode-toggle button {
+  flex: 1;
+  padding: 3px 8px;
+  font-size: 0.7em;
+  border-radius: 0;
+  border: 1px solid var(--bg-tertiary);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.voicing-mode-toggle button:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+}
+
+.voicing-mode-toggle button.active {
+  background: var(--note-chord);
+  border-color: var(--note-chord);
+  color: #fff;
+}
+
+.voicing-mode-toggle button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.voicing-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.voicing-nav button {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  font-size: 0.7em;
+  background: var(--bg-tertiary);
+  border: none;
+  border-radius: 3px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.voicing-nav button:hover:not(:disabled) {
+  background: var(--note-chord);
+  color: #fff;
+}
+
+.voicing-nav button:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.voicing-index {
+  font-size: 0.7em;
+  color: var(--text-secondary);
+  min-width: 30px;
+  text-align: center;
+}

--- a/src/components/VoicingControls/VoicingControls.css
+++ b/src/components/VoicingControls/VoicingControls.css
@@ -1,0 +1,192 @@
+/* Voicing Controls */
+.voicing-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  background: var(--bg-tertiary);
+  border-radius: 6px;
+  margin-top: 8px;
+}
+
+.voicing-controls.compact {
+  padding: 4px 8px;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* View Mode Toggle (All Notes / Voicing) */
+.voicing-view-toggle {
+  display: flex;
+  gap: 0;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--bg-primary);
+}
+
+.voicing-view-toggle button {
+  border-radius: 0;
+  border: none;
+  padding: 0.4em 0.8em;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: 0.85em;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.voicing-view-toggle button:hover:not(:disabled) {
+  background: var(--bg-secondary);
+}
+
+.voicing-view-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.voicing-view-toggle button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.voicing-view-toggle button:first-child {
+  border-radius: 5px 0 0 5px;
+}
+
+.voicing-view-toggle button:last-child {
+  border-radius: 0 5px 5px 0;
+}
+
+.voicing-controls.compact .voicing-view-toggle button {
+  padding: 0.3em 0.6em;
+  font-size: 0.8em;
+}
+
+/* Position Selector */
+.voicing-position-selector {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.voicing-nav-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border: 1px solid var(--bg-secondary);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.voicing-nav-btn:hover:not(:disabled) {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.voicing-nav-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.nav-arrow {
+  font-size: 0.8em;
+  line-height: 1;
+}
+
+.voicing-controls.compact .voicing-nav-btn {
+  width: 24px;
+  height: 24px;
+}
+
+.voicing-controls.compact .nav-arrow {
+  font-size: 0.7em;
+}
+
+/* Voicing Dropdown */
+.voicing-dropdown {
+  min-width: 140px;
+  padding: 0.4em 0.6em;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--bg-secondary);
+  border-radius: 4px;
+  font-size: 0.85em;
+  cursor: pointer;
+}
+
+.voicing-dropdown:hover {
+  border-color: var(--accent);
+}
+
+.voicing-controls.compact .voicing-dropdown {
+  min-width: 100px;
+  font-size: 0.8em;
+  padding: 0.3em 0.5em;
+}
+
+/* Voicing Badge */
+.voicing-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 0.75em;
+  font-weight: 500;
+  border-radius: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.voicing-badge.open {
+  background: rgba(76, 175, 80, 0.2);
+  color: #4caf50;
+}
+
+.voicing-badge.barre {
+  background: rgba(33, 150, 243, 0.2);
+  color: #2196f3;
+}
+
+.voicing-badge.partial_barre {
+  background: rgba(255, 152, 0, 0.2);
+  color: #ff9800;
+}
+
+.voicing-badge.caged {
+  background: rgba(156, 39, 176, 0.2);
+  color: #9c27b0;
+}
+
+.voicing-badge.generated {
+  background: rgba(158, 158, 158, 0.2);
+  color: #9e9e9e;
+}
+
+/* Voicing Count */
+.voicing-count {
+  font-size: 0.8em;
+  color: var(--text-secondary);
+  padding-left: 8px;
+  border-left: 1px solid var(--bg-primary);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .voicing-controls {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .voicing-dropdown {
+    min-width: 120px;
+  }
+
+  .voicing-badge {
+    display: none;
+  }
+}

--- a/src/components/VoicingControls/VoicingControls.jsx
+++ b/src/components/VoicingControls/VoicingControls.jsx
@@ -1,0 +1,106 @@
+import './VoicingControls.css';
+
+function VoicingControls({
+  voicingMode,
+  setVoicingMode,
+  selectedVoicingIndex,
+  setSelectedVoicingIndex,
+  availableVoicings,
+  compact = false
+}) {
+  const hasVoicings = availableVoicings && availableVoicings.length > 0;
+  const canGoPrev = selectedVoicingIndex > 0;
+  const canGoNext = selectedVoicingIndex < availableVoicings.length - 1;
+
+  const handlePrev = () => {
+    if (canGoPrev) {
+      setSelectedVoicingIndex(selectedVoicingIndex - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (canGoNext) {
+      setSelectedVoicingIndex(selectedVoicingIndex + 1);
+    }
+  };
+
+  const currentVoicing = hasVoicings ? availableVoicings[selectedVoicingIndex] : null;
+
+  return (
+    <div className={`voicing-controls ${compact ? 'compact' : ''}`}>
+      {/* View mode toggle */}
+      <div className="voicing-view-toggle">
+        <button
+          className={voicingMode === 'all' ? 'active' : ''}
+          onClick={() => setVoicingMode('all')}
+          title="Show all chord notes across the fretboard"
+        >
+          All Notes
+        </button>
+        <button
+          className={voicingMode === 'voicing' ? 'active' : ''}
+          onClick={() => setVoicingMode('voicing')}
+          disabled={!hasVoicings}
+          title={hasVoicings ? 'Show playable chord positions' : 'No voicings available'}
+        >
+          Voicing
+        </button>
+      </div>
+
+      {/* Position selector - only show when in voicing mode */}
+      {voicingMode === 'voicing' && hasVoicings && (
+        <div className="voicing-position-selector">
+          <button
+            className="voicing-nav-btn"
+            onClick={handlePrev}
+            disabled={!canGoPrev}
+            title="Previous voicing"
+          >
+            <span className="nav-arrow">&#9664;</span>
+          </button>
+
+          <select
+            value={selectedVoicingIndex}
+            onChange={(e) => setSelectedVoicingIndex(parseInt(e.target.value))}
+            className="voicing-dropdown"
+          >
+            {availableVoicings.map((v, idx) => (
+              <option key={v.id || idx} value={idx}>
+                {v.name}
+              </option>
+            ))}
+          </select>
+
+          <button
+            className="voicing-nav-btn"
+            onClick={handleNext}
+            disabled={!canGoNext}
+            title="Next voicing"
+          >
+            <span className="nav-arrow">&#9654;</span>
+          </button>
+
+          {/* Voicing info badge */}
+          {currentVoicing && !compact && (
+            <span className={`voicing-badge ${currentVoicing.category}`}>
+              {currentVoicing.category === 'open' && 'Open'}
+              {currentVoicing.category === 'barre' && 'Barre'}
+              {currentVoicing.category === 'partial_barre' && 'Partial'}
+              {currentVoicing.category === 'caged' && 'CAGED'}
+              {currentVoicing.category === 'generated' && 'Generated'}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Show count when voicings available */}
+      {voicingMode === 'voicing' && hasVoicings && !compact && (
+        <span className="voicing-count">
+          {selectedVoicingIndex + 1} of {availableVoicings.length}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default VoicingControls;

--- a/src/data/voicings.js
+++ b/src/data/voicings.js
@@ -1,0 +1,595 @@
+// Chord voicing definitions
+// Each voicing defines exact string/fret positions for a playable chord shape
+// String indices: 0 = low E, 1 = A, 2 = D, 3 = G, 4 = B, 5 = high e
+// Fret values: null = muted (don't play), 0 = open string, 1+ = fret number
+
+// ============================================================================
+// OPEN CHORD VOICINGS (Root-specific, for standard tuning)
+// ============================================================================
+
+export const OPEN_VOICINGS = {
+  major: {
+    'C': [
+      {
+        id: 'c_major_open',
+        name: 'C Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: 3 },     // A - 3rd fret (C)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 1 },     // B - 1st fret (C)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'G': [
+      {
+        id: 'g_major_open',
+        name: 'G Open',
+        positions: [
+          { string: 0, fret: 3 },     // Low E - 3rd fret (G)
+          { string: 1, fret: 2 },     // A - 2nd fret (B)
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 0 },     // B - open (B)
+          { string: 5, fret: 3 }      // e - 3rd fret (G)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      },
+      {
+        id: 'g_major_open_alt',
+        name: 'G Open (Alt)',
+        positions: [
+          { string: 0, fret: 3 },     // Low E - 3rd fret (G)
+          { string: 1, fret: 2 },     // A - 2nd fret (B)
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 3 },     // B - 3rd fret (D)
+          { string: 5, fret: 3 }      // e - 3rd fret (G)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'D': [
+      {
+        id: 'd_major_open',
+        name: 'D Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: null },  // A - muted
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 2 },     // G - 2nd fret (A)
+          { string: 4, fret: 3 },     // B - 3rd fret (D)
+          { string: 5, fret: 2 }      // e - 2nd fret (F#)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'A': [
+      {
+        id: 'a_major_open',
+        name: 'A Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: 0 },     // A - open (A)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 2 },     // G - 2nd fret (A)
+          { string: 4, fret: 2 },     // B - 2nd fret (C#)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'E': [
+      {
+        id: 'e_major_open',
+        name: 'E Open',
+        positions: [
+          { string: 0, fret: 0 },     // Low E - open (E)
+          { string: 1, fret: 2 },     // A - 2nd fret (B)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 1 },     // G - 1st fret (G#)
+          { string: 4, fret: 0 },     // B - open (B)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'F': [
+      {
+        id: 'f_major_partial',
+        name: 'F (Mini Barre)',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: null },  // A - muted
+          { string: 2, fret: 3 },     // D - 3rd fret (F)
+          { string: 3, fret: 2 },     // G - 2nd fret (A)
+          { string: 4, fret: 1 },     // B - 1st fret (C)
+          { string: 5, fret: 1 }      // e - 1st fret (F)
+        ],
+        barreInfo: { fret: 1, fromString: 4, toString: 5 },
+        category: 'partial_barre',
+        difficulty: 'intermediate'
+      }
+    ]
+  },
+
+  minor: {
+    'A': [
+      {
+        id: 'a_minor_open',
+        name: 'Am Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: 0 },     // A - open (A)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 2 },     // G - 2nd fret (A)
+          { string: 4, fret: 1 },     // B - 1st fret (C)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'E': [
+      {
+        id: 'e_minor_open',
+        name: 'Em Open',
+        positions: [
+          { string: 0, fret: 0 },     // Low E - open (E)
+          { string: 1, fret: 2 },     // A - 2nd fret (B)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 0 },     // B - open (B)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'D': [
+      {
+        id: 'd_minor_open',
+        name: 'Dm Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: null },  // A - muted
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 2 },     // G - 2nd fret (A)
+          { string: 4, fret: 3 },     // B - 3rd fret (D)
+          { string: 5, fret: 1 }      // e - 1st fret (F)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ]
+  },
+
+  dom7: {
+    'E': [
+      {
+        id: 'e7_open',
+        name: 'E7 Open',
+        positions: [
+          { string: 0, fret: 0 },     // Low E - open (E)
+          { string: 1, fret: 2 },     // A - 2nd fret (B)
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 1 },     // G - 1st fret (G#)
+          { string: 4, fret: 0 },     // B - open (B)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'A': [
+      {
+        id: 'a7_open',
+        name: 'A7 Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: 0 },     // A - open (A)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 2 },     // B - 2nd fret (C#)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'D': [
+      {
+        id: 'd7_open',
+        name: 'D7 Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: null },  // A - muted
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 2 },     // G - 2nd fret (A)
+          { string: 4, fret: 1 },     // B - 1st fret (C)
+          { string: 5, fret: 2 }      // e - 2nd fret (F#)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'G': [
+      {
+        id: 'g7_open',
+        name: 'G7 Open',
+        positions: [
+          { string: 0, fret: 3 },     // Low E - 3rd fret (G)
+          { string: 1, fret: 2 },     // A - 2nd fret (B)
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 0 },     // B - open (B)
+          { string: 5, fret: 1 }      // e - 1st fret (F)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'C': [
+      {
+        id: 'c7_open',
+        name: 'C7 Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: 3 },     // A - 3rd fret (C)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 3 },     // G - 3rd fret (Bb)
+          { string: 4, fret: 1 },     // B - 1st fret (C)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ]
+  },
+
+  maj7: {
+    'C': [
+      {
+        id: 'cmaj7_open',
+        name: 'Cmaj7 Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: 3 },     // A - 3rd fret (C)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 0 },     // B - open (B)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'G': [
+      {
+        id: 'gmaj7_open',
+        name: 'Gmaj7 Open',
+        positions: [
+          { string: 0, fret: 3 },     // Low E - 3rd fret (G)
+          { string: 1, fret: 2 },     // A - 2nd fret (B)
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 0 },     // B - open (B)
+          { string: 5, fret: 2 }      // e - 2nd fret (F#)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'F': [
+      {
+        id: 'fmaj7_open',
+        name: 'Fmaj7 Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: null },  // A - muted
+          { string: 2, fret: 3 },     // D - 3rd fret (F)
+          { string: 3, fret: 2 },     // G - 2nd fret (A)
+          { string: 4, fret: 1 },     // B - 1st fret (C)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'D': [
+      {
+        id: 'dmaj7_open',
+        name: 'Dmaj7 Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: null },  // A - muted
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 2 },     // G - 2nd fret (A)
+          { string: 4, fret: 2 },     // B - 2nd fret (C#)
+          { string: 5, fret: 2 }      // e - 2nd fret (F#)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'A': [
+      {
+        id: 'amaj7_open',
+        name: 'Amaj7 Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: 0 },     // A - open (A)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 1 },     // G - 1st fret (G#)
+          { string: 4, fret: 2 },     // B - 2nd fret (C#)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ]
+  },
+
+  min7: {
+    'A': [
+      {
+        id: 'am7_open',
+        name: 'Am7 Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: 0 },     // A - open (A)
+          { string: 2, fret: 2 },     // D - 2nd fret (E)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 1 },     // B - 1st fret (C)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'E': [
+      {
+        id: 'em7_open',
+        name: 'Em7 Open',
+        positions: [
+          { string: 0, fret: 0 },     // Low E - open (E)
+          { string: 1, fret: 2 },     // A - 2nd fret (B)
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 0 },     // G - open (G)
+          { string: 4, fret: 0 },     // B - open (B)
+          { string: 5, fret: 0 }      // e - open (E)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ],
+    'D': [
+      {
+        id: 'dm7_open',
+        name: 'Dm7 Open',
+        positions: [
+          { string: 0, fret: null },  // Low E - muted
+          { string: 1, fret: null },  // A - muted
+          { string: 2, fret: 0 },     // D - open (D)
+          { string: 3, fret: 2 },     // G - 2nd fret (A)
+          { string: 4, fret: 1 },     // B - 1st fret (C)
+          { string: 5, fret: 1 }      // e - 1st fret (F)
+        ],
+        category: 'open',
+        difficulty: 'beginner'
+      }
+    ]
+  }
+};
+
+// ============================================================================
+// MOVEABLE (BARRE) CHORD SHAPES
+// These can be transposed to any root note by moving up/down the neck
+// rootString = which string has the root note (for calculating position)
+// basePosition = array represents the shape with frets relative to root fret
+// ============================================================================
+
+export const MOVEABLE_VOICINGS = {
+  major: [
+    {
+      id: 'major_e_shape',
+      name: 'E-Shape Barre',
+      rootString: 0,           // Root is on low E string
+      // Positions relative to root fret (root fret = 0)
+      basePositions: [
+        { string: 0, fret: 0 },     // Root
+        { string: 1, fret: 2 },
+        { string: 2, fret: 2 },
+        { string: 3, fret: 1 },
+        { string: 4, fret: 0 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 0, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    },
+    {
+      id: 'major_a_shape',
+      name: 'A-Shape Barre',
+      rootString: 1,           // Root is on A string
+      basePositions: [
+        { string: 0, fret: null },  // Muted
+        { string: 1, fret: 0 },     // Root
+        { string: 2, fret: 2 },
+        { string: 3, fret: 2 },
+        { string: 4, fret: 2 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 1, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    },
+    {
+      id: 'major_c_shape',
+      name: 'C-Shape',
+      rootString: 1,           // Root on A string
+      basePositions: [
+        { string: 0, fret: null },
+        { string: 1, fret: 0 },     // Root
+        { string: 2, fret: -1 },    // One fret below root
+        { string: 3, fret: -3 },
+        { string: 4, fret: -2 },
+        { string: 5, fret: -3 }
+      ],
+      category: 'caged',
+      difficulty: 'advanced'
+    }
+  ],
+
+  minor: [
+    {
+      id: 'minor_e_shape',
+      name: 'Em-Shape Barre',
+      rootString: 0,
+      basePositions: [
+        { string: 0, fret: 0 },     // Root
+        { string: 1, fret: 2 },
+        { string: 2, fret: 2 },
+        { string: 3, fret: 0 },
+        { string: 4, fret: 0 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 0, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    },
+    {
+      id: 'minor_a_shape',
+      name: 'Am-Shape Barre',
+      rootString: 1,
+      basePositions: [
+        { string: 0, fret: null },
+        { string: 1, fret: 0 },     // Root
+        { string: 2, fret: 2 },
+        { string: 3, fret: 2 },
+        { string: 4, fret: 1 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 1, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    }
+  ],
+
+  dom7: [
+    {
+      id: 'dom7_e_shape',
+      name: 'E7-Shape Barre',
+      rootString: 0,
+      basePositions: [
+        { string: 0, fret: 0 },     // Root
+        { string: 1, fret: 2 },
+        { string: 2, fret: 0 },
+        { string: 3, fret: 1 },
+        { string: 4, fret: 0 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 0, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    },
+    {
+      id: 'dom7_a_shape',
+      name: 'A7-Shape Barre',
+      rootString: 1,
+      basePositions: [
+        { string: 0, fret: null },
+        { string: 1, fret: 0 },     // Root
+        { string: 2, fret: 2 },
+        { string: 3, fret: 0 },
+        { string: 4, fret: 2 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 1, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    }
+  ],
+
+  min7: [
+    {
+      id: 'min7_e_shape',
+      name: 'Em7-Shape Barre',
+      rootString: 0,
+      basePositions: [
+        { string: 0, fret: 0 },     // Root
+        { string: 1, fret: 2 },
+        { string: 2, fret: 0 },
+        { string: 3, fret: 0 },
+        { string: 4, fret: 0 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 0, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    },
+    {
+      id: 'min7_a_shape',
+      name: 'Am7-Shape Barre',
+      rootString: 1,
+      basePositions: [
+        { string: 0, fret: null },
+        { string: 1, fret: 0 },     // Root
+        { string: 2, fret: 2 },
+        { string: 3, fret: 0 },
+        { string: 4, fret: 1 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 1, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    }
+  ],
+
+  maj7: [
+    {
+      id: 'maj7_e_shape',
+      name: 'Emaj7-Shape Barre',
+      rootString: 0,
+      basePositions: [
+        { string: 0, fret: 0 },     // Root
+        { string: 1, fret: 2 },
+        { string: 2, fret: 1 },
+        { string: 3, fret: 1 },
+        { string: 4, fret: 0 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 0, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    },
+    {
+      id: 'maj7_a_shape',
+      name: 'Amaj7-Shape Barre',
+      rootString: 1,
+      basePositions: [
+        { string: 0, fret: null },
+        { string: 1, fret: 0 },     // Root
+        { string: 2, fret: 2 },
+        { string: 3, fret: 1 },
+        { string: 4, fret: 2 },
+        { string: 5, fret: 0 }
+      ],
+      barreInfo: { fretOffset: 0, fromString: 1, toString: 5 },
+      category: 'barre',
+      difficulty: 'intermediate'
+    }
+  ]
+};
+
+// Standard tuning for reference
+export const STANDARD_TUNING = ['E', 'A', 'D', 'G', 'B', 'E'];

--- a/src/utils/voicingUtils.js
+++ b/src/utils/voicingUtils.js
@@ -1,0 +1,347 @@
+// Utility functions for chord voicings
+import { NOTES, getNoteIndex, getNoteOnFret } from '../data/notes';
+import { OPEN_VOICINGS, MOVEABLE_VOICINGS, STANDARD_TUNING } from '../data/voicings';
+import { getChordNotes } from './musicTheory';
+
+/**
+ * Find the fret position for a specific note on a given string
+ * @param {string} targetNote - The note to find (e.g., 'C', 'F#')
+ * @param {string} openStringNote - The open string note
+ * @param {number} maxFret - Maximum fret to search
+ * @returns {number[]} Array of fret positions where the note occurs
+ */
+export function findNoteOnString(targetNote, openStringNote, maxFret = 22) {
+  const positions = [];
+  for (let fret = 0; fret <= maxFret; fret++) {
+    if (getNoteOnFret(openStringNote, fret) === targetNote) {
+      positions.push(fret);
+    }
+  }
+  return positions;
+}
+
+/**
+ * Calculate fret offset needed to transpose a moveable shape to a target root
+ * @param {string} targetRoot - The target root note
+ * @param {number} rootString - Which string has the root (0-5)
+ * @param {string[]} tuning - Current tuning
+ * @returns {number} Fret offset from open position
+ */
+export function calculateRootFretOffset(targetRoot, rootString, tuning = STANDARD_TUNING) {
+  const openNote = tuning[rootString];
+  const openNoteIndex = getNoteIndex(openNote);
+  const targetIndex = getNoteIndex(targetRoot);
+
+  // Calculate semitones from open note to target
+  let offset = (targetIndex - openNoteIndex + 12) % 12;
+
+  return offset;
+}
+
+/**
+ * Transpose a moveable voicing shape to a specific root note
+ * @param {Object} moveableVoicing - The moveable voicing template
+ * @param {string} targetRoot - Target root note
+ * @param {string[]} tuning - Current tuning
+ * @returns {Object} Transposed voicing with absolute fret positions
+ */
+export function transposeVoicing(moveableVoicing, targetRoot, tuning = STANDARD_TUNING) {
+  const fretOffset = calculateRootFretOffset(targetRoot, moveableVoicing.rootString, tuning);
+
+  // Skip if this would put the chord at fret 0 (use open voicing instead)
+  // or beyond the fretboard
+  if (fretOffset === 0) {
+    return null; // Let open voicing be used instead
+  }
+
+  const transposedPositions = moveableVoicing.basePositions.map(pos => {
+    if (pos.fret === null) {
+      return { string: pos.string, fret: null };
+    }
+    const newFret = pos.fret + fretOffset;
+    // Skip if fret is negative or too high
+    if (newFret < 0 || newFret > 22) {
+      return { string: pos.string, fret: null };
+    }
+    return { string: pos.string, fret: newFret };
+  });
+
+  // Check if any required notes ended up muted (invalid transposition)
+  const hasInvalidFrets = transposedPositions.some(
+    (pos, i) => moveableVoicing.basePositions[i].fret !== null && pos.fret === null
+  );
+
+  if (hasInvalidFrets) {
+    return null;
+  }
+
+  // Calculate barre info if present
+  let transposedBarreInfo = null;
+  if (moveableVoicing.barreInfo) {
+    transposedBarreInfo = {
+      fret: moveableVoicing.barreInfo.fretOffset + fretOffset,
+      fromString: moveableVoicing.barreInfo.fromString,
+      toString: moveableVoicing.barreInfo.toString
+    };
+  }
+
+  return {
+    id: `${moveableVoicing.id}_${targetRoot.replace('#', 'sharp')}`,
+    name: `${targetRoot} ${moveableVoicing.name}`,
+    positions: transposedPositions,
+    barreInfo: transposedBarreInfo,
+    category: moveableVoicing.category,
+    difficulty: moveableVoicing.difficulty,
+    basedOn: moveableVoicing.id,
+    rootFret: fretOffset
+  };
+}
+
+/**
+ * Get all available voicings for a chord (open + transposed moveable)
+ * @param {string} rootNote - Root note of the chord
+ * @param {string} chordType - Type of chord (major, minor, etc.)
+ * @param {string[]} tuning - Current tuning
+ * @returns {Object[]} Array of voicing objects
+ */
+export function getVoicingsForChord(rootNote, chordType, tuning = STANDARD_TUNING) {
+  const voicings = [];
+
+  // Check for open voicings first
+  const openVoicingsForType = OPEN_VOICINGS[chordType];
+  if (openVoicingsForType && openVoicingsForType[rootNote]) {
+    voicings.push(...openVoicingsForType[rootNote]);
+  }
+
+  // Get moveable voicings and transpose them
+  const moveableVoicingsForType = MOVEABLE_VOICINGS[chordType];
+  if (moveableVoicingsForType) {
+    for (const moveable of moveableVoicingsForType) {
+      const transposed = transposeVoicing(moveable, rootNote, tuning);
+      if (transposed) {
+        voicings.push(transposed);
+      }
+    }
+  }
+
+  // If no predefined voicings, generate algorithmically
+  if (voicings.length === 0) {
+    const generated = generateVoicings(rootNote, chordType, tuning);
+    voicings.push(...generated);
+  }
+
+  // Sort by difficulty and then by position on neck
+  voicings.sort((a, b) => {
+    const difficultyOrder = { beginner: 0, intermediate: 1, advanced: 2 };
+    const aDiff = difficultyOrder[a.difficulty] ?? 1;
+    const bDiff = difficultyOrder[b.difficulty] ?? 1;
+    if (aDiff !== bDiff) return aDiff - bDiff;
+
+    // Then by lowest fret position
+    const aMinFret = Math.min(...a.positions.filter(p => p.fret !== null).map(p => p.fret));
+    const bMinFret = Math.min(...b.positions.filter(p => p.fret !== null).map(p => p.fret));
+    return aMinFret - bMinFret;
+  });
+
+  return voicings;
+}
+
+/**
+ * Generate voicings algorithmically for chords without predefined shapes
+ * @param {string} rootNote - Root note
+ * @param {string} chordType - Chord type
+ * @param {string[]} tuning - Current tuning
+ * @param {Object} options - Generation options
+ * @returns {Object[]} Array of generated voicings
+ */
+export function generateVoicings(rootNote, chordType, tuning = STANDARD_TUNING, options = {}) {
+  const { maxFretSpan = 4, numVoicings = 4, minFret = 0, maxFret = 12 } = options;
+
+  const chordNotes = getChordNotes(rootNote, chordType);
+  if (!chordNotes.length) return [];
+
+  const voicings = [];
+  const stringCount = tuning.length;
+
+  // Find all positions for each chord note on each string
+  const notePositions = [];
+  for (let stringIdx = 0; stringIdx < stringCount; stringIdx++) {
+    const stringPositions = [];
+    for (const note of chordNotes) {
+      const frets = findNoteOnString(note, tuning[stringIdx], maxFret);
+      for (const fret of frets) {
+        if (fret >= minFret) {
+          stringPositions.push({ note, fret });
+        }
+      }
+    }
+    notePositions.push(stringPositions);
+  }
+
+  // Generate voicings at different fret regions
+  const regions = [
+    { start: 0, end: 4 },
+    { start: 5, end: 9 },
+    { start: 7, end: 11 },
+    { start: 10, end: 14 }
+  ];
+
+  for (const region of regions) {
+    const voicing = generateVoicingInRegion(
+      notePositions,
+      chordNotes,
+      rootNote,
+      region.start,
+      region.end,
+      maxFretSpan,
+      stringCount
+    );
+
+    if (voicing) {
+      voicings.push({
+        id: `generated_${rootNote}_${chordType}_${region.start}`,
+        name: `Position ${region.start === 0 ? 'Open' : `Fret ${region.start}`}`,
+        positions: voicing,
+        category: 'generated',
+        difficulty: region.start === 0 ? 'beginner' : 'intermediate'
+      });
+    }
+
+    if (voicings.length >= numVoicings) break;
+  }
+
+  return voicings;
+}
+
+/**
+ * Generate a single voicing within a fret region
+ */
+function generateVoicingInRegion(notePositions, chordNotes, rootNote, minFret, maxFret, maxSpan, stringCount) {
+  const positions = [];
+  let usedNotes = new Set();
+  let fretMin = Infinity;
+  let fretMax = -Infinity;
+
+  // Try to place notes on strings from low to high
+  for (let stringIdx = 0; stringIdx < stringCount; stringIdx++) {
+    const availableOnString = notePositions[stringIdx].filter(
+      p => p.fret >= minFret && p.fret <= maxFret
+    );
+
+    if (availableOnString.length === 0) {
+      positions.push({ string: stringIdx, fret: null });
+      continue;
+    }
+
+    // Prioritize: 1) root note, 2) unused chord tones, 3) any chord tone
+    let bestPosition = null;
+
+    // First priority: root note if not used yet
+    if (!usedNotes.has(rootNote)) {
+      bestPosition = availableOnString.find(p => p.note === rootNote);
+    }
+
+    // Second priority: unused chord tones
+    if (!bestPosition) {
+      for (const note of chordNotes) {
+        if (!usedNotes.has(note)) {
+          const pos = availableOnString.find(p => p.note === note);
+          if (pos && wouldFitSpan(pos.fret, fretMin, fretMax, maxSpan)) {
+            bestPosition = pos;
+            break;
+          }
+        }
+      }
+    }
+
+    // Third priority: any chord tone that fits the span
+    if (!bestPosition) {
+      for (const pos of availableOnString) {
+        if (wouldFitSpan(pos.fret, fretMin, fretMax, maxSpan)) {
+          bestPosition = pos;
+          break;
+        }
+      }
+    }
+
+    if (bestPosition) {
+      positions.push({ string: stringIdx, fret: bestPosition.fret });
+      usedNotes.add(bestPosition.note);
+      if (bestPosition.fret > 0) {
+        fretMin = Math.min(fretMin, bestPosition.fret);
+        fretMax = Math.max(fretMax, bestPosition.fret);
+      }
+    } else {
+      positions.push({ string: stringIdx, fret: null });
+    }
+  }
+
+  // Validate: must have at least 3 strings played and include the root
+  const playedStrings = positions.filter(p => p.fret !== null).length;
+  if (playedStrings < 3 || !usedNotes.has(rootNote)) {
+    return null;
+  }
+
+  return positions;
+}
+
+/**
+ * Check if adding a fret would keep within max span
+ */
+function wouldFitSpan(fret, currentMin, currentMax, maxSpan) {
+  if (fret === 0) return true; // Open strings don't count toward span
+  if (currentMin === Infinity) return true;
+
+  const newMin = Math.min(currentMin, fret);
+  const newMax = Math.max(currentMax, fret);
+
+  // Only count frets > 0 for span calculation
+  return (newMax - newMin) <= maxSpan;
+}
+
+/**
+ * Convert voicing positions to fretboard highlight format
+ * @param {Object} voicing - Voicing object
+ * @param {string[]} tuning - Current tuning
+ * @returns {Object[]} Array of { stringIndex, fret, note, isMuted }
+ */
+export function voicingToFretPositions(voicing, tuning = STANDARD_TUNING) {
+  if (!voicing || !voicing.positions) return [];
+
+  return voicing.positions.map((pos, idx) => {
+    const stringIndex = pos.string;
+    const isMuted = pos.fret === null;
+    const note = isMuted ? null : getNoteOnFret(tuning[stringIndex], pos.fret);
+
+    return {
+      stringIndex,
+      fret: pos.fret,
+      note,
+      isMuted
+    };
+  });
+}
+
+/**
+ * Get voicing dropdown options
+ * @param {Object[]} voicings - Array of voicing objects
+ * @returns {Object[]} Array of { value, label }
+ */
+export function getVoicingOptions(voicings) {
+  return voicings.map((v, idx) => ({
+    value: idx,
+    label: v.name,
+    category: v.category,
+    difficulty: v.difficulty
+  }));
+}
+
+/**
+ * Check if a tuning is standard (for determining if predefined voicings apply)
+ * @param {string[]} tuning - Current tuning
+ * @returns {boolean}
+ */
+export function isStandardTuning(tuning) {
+  if (tuning.length !== STANDARD_TUNING.length) return false;
+  return tuning.every((note, i) => note === STANDARD_TUNING[i]);
+}


### PR DESCRIPTION
## Summary
- Add ability to view and cycle through playable chord shapes instead of showing all chord tones across the entire neck
- Toggle between "All Notes" and "Voicing" view when in chord mode
- Predefined voicings for common chords (C, G, D, A, E, F major; Am, Em, Dm minor; plus 7th chords)
- Moveable barre shapes (E-shape, A-shape) for major, minor, dom7, min7, maj7
- Algorithmic voicing generation for chords without predefined shapes
- Voicing support integrated into Learn, Jam, and Practice modes
- New "Name That Shape" quiz type in Practice mode

## Test plan
- [ ] Learn mode: Switch to chord mode, verify VoicingControls appear
- [ ] Learn mode: Toggle between "All Notes" and "Voicing", verify display changes
- [ ] Learn mode: Cycle through voicings with arrows/dropdown
- [ ] Learn mode: Verify muted string indicators (X) appear for voicing mode
- [ ] Jam mode: Add chord step, verify "All" / "Shape" toggle appears
- [ ] Jam mode: Cycle through voicings with prev/next buttons
- [ ] Practice mode: Select "Name That Shape" quiz, verify voicing appears on fretboard
- [ ] Practice mode: Answer quiz questions, verify correct/incorrect feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)