### PR TITLE
Release v0.0.22: Fix chord voicing highlights on tuning change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Guitar Theory Lab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.22] - 2026-01-08
+
+### Fixed
+- Chord voicing highlights now update correctly when tuning changes
+  - Open voicings (C Open, G Open, etc.) are now only shown in standard tuning
+  - Updated src/utils/voicingUtils.js getVoicingsForChord() to filter open voicings by tuning
+  - Added tuning check using isStandardTuning() before including open voicings
+  - Open voicings are hardcoded for standard tuning and don't work in alternate tunings
+- Voicing selection now resets to first voicing when tuning changes
+  - Updated src/App.jsx to reset selectedVoicingIndex on tuning change (Learn mode)
+  - Added tuningKey to useEffect dependency array (line 113)
+- Jam mode voicing indices reset when tuning changes
+  - Updated src/components/Jam/Jam.jsx to reset all step voicing indices
+  - Added useEffect to map sequence and reset selectedVoicingIndex to 0 (lines 68-76)
+  - Prevents invalid voicing indices when available voicings change between tunings
+
 ## [0.0.21] - 2026-01-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,10 +107,10 @@ function App() {
     return getVoicingsForChord(rootNote, chordType, tuning);
   }, [mode, rootNote, chordType, tuning]);
 
-  // Reset voicing index when chord changes
+  // Reset voicing index when chord or tuning changes
   useEffect(() => {
     setSelectedVoicingIndex(0);
-  }, [rootNote, chordType]);
+  }, [rootNote, chordType, tuningKey]);
 
   // Compute voicing positions for fretboard display
   const voicingPositions = useMemo(() => {

--- a/src/components/Jam/Jam.jsx
+++ b/src/components/Jam/Jam.jsx
@@ -65,6 +65,16 @@ function Jam({ tuning, tabView, onHighlightChange }) {
   const isInitialMount = useRef(true);
   const activeOscillatorsRef = useRef([]); // Track active oscillators for stopping
 
+  // Reset voicing indices when tuning changes
+  useEffect(() => {
+    setSequence(prevSequence =>
+      prevSequence.map(step => ({
+        ...step,
+        selectedVoicingIndex: 0
+      }))
+    );
+  }, [tuning]);
+
   // Get current step
   const currentStep = sequence[currentStepIndex] || null;
 

--- a/src/utils/voicingUtils.js
+++ b/src/utils/voicingUtils.js
@@ -107,10 +107,12 @@ export function transposeVoicing(moveableVoicing, targetRoot, tuning = STANDARD_
 export function getVoicingsForChord(rootNote, chordType, tuning = STANDARD_TUNING) {
   const voicings = [];
 
-  // Check for open voicings first
-  const openVoicingsForType = OPEN_VOICINGS[chordType];
-  if (openVoicingsForType && openVoicingsForType[rootNote]) {
-    voicings.push(...openVoicingsForType[rootNote]);
+  // Check for open voicings first (ONLY in standard tuning)
+  if (isStandardTuning(tuning)) {
+    const openVoicingsForType = OPEN_VOICINGS[chordType];
+    if (openVoicingsForType && openVoicingsForType[rootNote]) {
+      voicings.push(...openVoicingsForType[rootNote]);
+    }
   }
 
   // Get moveable voicings and transpose them


### PR DESCRIPTION
## Summary

This release fixes a bug where chord voicing highlights would remain on the same physical fret positions when switching tunings, even though those positions produce different notes in alternate tunings.

- Open voicings (C Open, G Open, etc.) are now only shown in standard tuning
- Voicing selection resets to first available voicing when tuning changes
- Jam mode sequence steps reset voicing indices on tuning change
- Ensures fretboard always highlights correct notes for selected voicing in current tuning

## Changes

- **src/utils/voicingUtils.js** - Added `isStandardTuning()` check before including open voicings
- **src/App.jsx** - Reset `selectedVoicingIndex` when `tuningKey` changes (Learn mode)
- **src/components/Jam/Jam.jsx** - Reset all step voicing indices when tuning changes
- **package.json** - Version bump to 0.0.22
- **CHANGELOG.md** - Documented bug fix with file locations

## Test Plan

- [x] Learn Mode: Switch from Standard to Drop D with C major chord in voicing mode
- [x] Verify open voicings disappear in alternate tunings
- [x] Verify voicing resets to #0 when tuning changes
- [x] Jam Mode: Switch tunings with multiple chord steps using specific voicings
- [x] Verify all steps reset voicing indices correctly
- [x] Verify highlighted positions match correct notes in new tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)