### PR TITLE
Release v0.0.28: Add chord voicing playback in Learn mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to Guitar Theory Lab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.28] - 2026-01-21
+
+### Added
+- **Chord Voicing Playback** - Hear how chord voicings sound in Learn mode
+  - Play button appears next to voicing selector when in Voicing view
+  - Two playback modes with toggle:
+    - **Strum**: Notes play sequentially from low to high string (~40ms gaps), like strumming a guitar
+    - **Chord**: All notes play simultaneously
+  - Uses Web Audio API with triangle waveform for guitar-like tone
+  - Correctly calculates pitch based on string and fret position
+  - Muted strings are automatically skipped during playback
+  - Audio context initializes on first play (browser autoplay policy compliant)
+- New file `src/utils/voicingAudio.js` with:
+  - `playVoicingStrum()` - Sequential note playback
+  - `playVoicingSimultaneous()` - Simultaneous note playback
+  - `getVoicingNotes()` - Extracts playable notes from voicing data
+  - `noteToFrequency()` - Converts note/octave to Hz using equal temperament
+  - `getOctaveForPosition()` - Calculates correct octave for string/fret position
+
+### Changed
+- Updated `src/components/VoicingControls/VoicingControls.jsx`:
+  - Added play button with playing state animation
+  - Added Strum/Chord playback mode toggle
+  - New props: `onPlayVoicing`, `playbackMode`, `setPlaybackMode`
+- Updated `src/components/VoicingControls/VoicingControls.css`:
+  - Play button styling with hover/active/disabled states
+  - Pulse animation during playback
+  - Playback mode toggle styling
+  - Voicing footer layout for toggle and count
+- Updated `src/components/Controls/Controls.jsx` to pass audio props to VoicingControls
+- Updated `src/App.jsx`:
+  - Added `playbackMode` state management
+  - Added `audioContextRef` for lazy audio context initialization
+  - Added `handlePlayVoicing` callback for audio playback
+
 ## [0.0.27] - 2026-01-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guitar-theory-lab",
   "private": true,
-  "version": "0.0.27",
+  "version": "0.0.28",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -29,7 +29,10 @@ function Controls({
   setVoicingMode,
   selectedVoicingIndex,
   setSelectedVoicingIndex,
-  availableVoicings
+  availableVoicings,
+  onPlayVoicing,
+  playbackMode,
+  setPlaybackMode
 }) {
   const scaleOptions = useMemo(() => getScaleOptions(), []);
   const chordOptions = useMemo(() => getChordOptions(), []);
@@ -103,6 +106,9 @@ function Controls({
               selectedVoicingIndex={selectedVoicingIndex}
               setSelectedVoicingIndex={setSelectedVoicingIndex}
               availableVoicings={availableVoicings}
+              onPlayVoicing={onPlayVoicing}
+              playbackMode={playbackMode}
+              setPlaybackMode={setPlaybackMode}
             />
           </>
         )}

--- a/src/components/VoicingControls/VoicingControls.css
+++ b/src/components/VoicingControls/VoicingControls.css
@@ -167,12 +167,108 @@
   color: #9e9e9e;
 }
 
+/* Play Button */
+.voicing-play-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 28px;
+  padding: 0;
+  margin-left: 4px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.voicing-play-btn:hover:not(:disabled) {
+  background: var(--accent-hover, #3d8b40);
+  transform: scale(1.05);
+}
+
+.voicing-play-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.voicing-play-btn.playing {
+  animation: pulse 0.6s ease-in-out;
+}
+
+.play-icon {
+  font-size: 0.9em;
+  line-height: 1;
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+  100% { transform: scale(1); }
+}
+
+.voicing-controls.compact .voicing-play-btn {
+  width: 28px;
+  height: 24px;
+}
+
+.voicing-controls.compact .play-icon {
+  font-size: 0.8em;
+}
+
+/* Voicing Footer (count + playback toggle) */
+.voicing-footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+}
+
+/* Playback Mode Toggle */
+.playback-mode-toggle {
+  display: flex;
+  gap: 0;
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid var(--bg-primary);
+}
+
+.playback-mode-toggle button {
+  border-radius: 0;
+  border: none;
+  padding: 0.25em 0.5em;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: 0.75em;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.playback-mode-toggle button:hover:not(:disabled) {
+  background: var(--bg-secondary);
+}
+
+.playback-mode-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.playback-mode-toggle button:first-child {
+  border-radius: 3px 0 0 3px;
+}
+
+.playback-mode-toggle button:last-child {
+  border-radius: 0 3px 3px 0;
+}
+
 /* Voicing Count */
 .voicing-count {
   font-size: 0.8em;
   color: var(--text-secondary);
-  padding-left: 8px;
-  border-left: 1px solid var(--bg-primary);
+  white-space: nowrap;
 }
 
 /* Responsive */

--- a/src/components/VoicingControls/VoicingControls.jsx
+++ b/src/components/VoicingControls/VoicingControls.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import './VoicingControls.css';
 
 function VoicingControls({
@@ -6,8 +7,13 @@ function VoicingControls({
   selectedVoicingIndex,
   setSelectedVoicingIndex,
   availableVoicings,
-  compact = false
+  compact = false,
+  onPlayVoicing = null,
+  playbackMode = 'strum',
+  setPlaybackMode = null
 }) {
+  const [isPlaying, setIsPlaying] = useState(false);
+
   const hasVoicings = availableVoicings && availableVoicings.length > 0;
   const canGoPrev = selectedVoicingIndex > 0;
   const canGoNext = selectedVoicingIndex < availableVoicings.length - 1;
@@ -21,6 +27,22 @@ function VoicingControls({
   const handleNext = () => {
     if (canGoNext) {
       setSelectedVoicingIndex(selectedVoicingIndex + 1);
+    }
+  };
+
+  const handlePlay = () => {
+    if (onPlayVoicing && !isPlaying) {
+      setIsPlaying(true);
+      onPlayVoicing();
+      // Reset playing state after playback duration
+      const duration = playbackMode === 'strum' ? 800 : 900;
+      setTimeout(() => setIsPlaying(false), duration);
+    }
+  };
+
+  const handlePlaybackModeToggle = () => {
+    if (setPlaybackMode) {
+      setPlaybackMode(playbackMode === 'strum' ? 'simultaneous' : 'strum');
     }
   };
 
@@ -80,6 +102,18 @@ function VoicingControls({
             <span className="nav-arrow">&#9654;</span>
           </button>
 
+          {/* Play button */}
+          {onPlayVoicing && (
+            <button
+              className={`voicing-play-btn ${isPlaying ? 'playing' : ''}`}
+              onClick={handlePlay}
+              disabled={isPlaying}
+              title={`Play voicing (${playbackMode === 'strum' ? 'Strum' : 'Chord'})`}
+            >
+              <span className="play-icon">&#9654;</span>
+            </button>
+          )}
+
           {/* Voicing info badge */}
           {currentVoicing && !compact && (
             <span className={`voicing-badge ${currentVoicing.category}`}>
@@ -93,11 +127,33 @@ function VoicingControls({
         </div>
       )}
 
-      {/* Show count when voicings available */}
+      {/* Playback mode toggle and count - only show when in voicing mode */}
       {voicingMode === 'voicing' && hasVoicings && !compact && (
-        <span className="voicing-count">
-          {selectedVoicingIndex + 1} of {availableVoicings.length}
-        </span>
+        <div className="voicing-footer">
+          {/* Playback mode toggle */}
+          {onPlayVoicing && setPlaybackMode && (
+            <div className="playback-mode-toggle">
+              <button
+                className={playbackMode === 'strum' ? 'active' : ''}
+                onClick={() => setPlaybackMode('strum')}
+                title="Play notes one at a time like strumming"
+              >
+                Strum
+              </button>
+              <button
+                className={playbackMode === 'simultaneous' ? 'active' : ''}
+                onClick={() => setPlaybackMode('simultaneous')}
+                title="Play all notes at once"
+              >
+                Chord
+              </button>
+            </div>
+          )}
+
+          <span className="voicing-count">
+            {selectedVoicingIndex + 1} of {availableVoicings.length}
+          </span>
+        </div>
       )}
     </div>
   );

--- a/src/utils/voicingAudio.js
+++ b/src/utils/voicingAudio.js
@@ -1,0 +1,246 @@
+/**
+ * Web Audio API utilities for playing chord voicings
+ * Provides both strum (arpeggio) and simultaneous playback
+ */
+
+import { getNoteIndex, getNoteOnFret } from '../data/notes';
+
+/**
+ * Base octaves for guitar strings in standard tuning
+ * String 0 (low E) = E2, String 5 (high e) = E4
+ */
+const STRING_BASE_OCTAVES = [2, 2, 3, 3, 3, 4]; // E2, A2, D3, G3, B3, E4
+
+/**
+ * Base semitones for each string's open note (in standard tuning)
+ * E=4, A=9, D=2, G=7, B=11, E=4
+ */
+const STANDARD_TUNING_SEMITONES = [4, 9, 2, 7, 11, 4]; // E, A, D, G, B, E
+
+/**
+ * Convert note name to frequency in Hz using equal temperament
+ * @param {string} note - Note name (e.g., "C", "D#", "Gb")
+ * @param {number} octave - Octave number (default: 4)
+ * @returns {number} Frequency in Hz
+ */
+export function noteToFrequency(note, octave = 4) {
+  const noteIndex = getNoteIndex(note);
+  // A4 = 440 Hz is the reference (index 9 in chromatic scale, octave 4)
+  const semitonesFromA4 = (noteIndex - 9) + ((octave - 4) * 12);
+  return 440 * Math.pow(2, semitonesFromA4 / 12);
+}
+
+/**
+ * Calculate the octave for a note on a specific string and fret
+ * @param {number} stringIndex - String index (0 = low E)
+ * @param {number} fret - Fret number (0 = open)
+ * @param {Array<string>} tuning - Array of open string notes
+ * @returns {number} Octave number
+ */
+export function getOctaveForPosition(stringIndex, fret, tuning) {
+  // Get the open note for this string
+  const openNote = tuning[stringIndex];
+  const openNoteIndex = getNoteIndex(openNote);
+
+  // Standard tuning reference for base octave
+  // Low E (string 0) is E2, High e (string 5) is E4
+  // We need to determine base octave from the string position
+  const baseOctave = STRING_BASE_OCTAVES[stringIndex] || 3;
+
+  // Calculate semitones from the open note
+  // Each 12 frets = 1 octave
+  const octaveOffset = Math.floor((openNoteIndex + fret) / 12) - Math.floor(openNoteIndex / 12);
+
+  return baseOctave + octaveOffset;
+}
+
+/**
+ * Get playable notes from a voicing (excluding muted strings)
+ * @param {Object} voicing - Voicing object with positions array
+ * @param {Array<string>} tuning - Current tuning
+ * @returns {Array<{note: string, octave: number, stringIndex: number}>} Array of note data
+ */
+export function getVoicingNotes(voicing, tuning) {
+  if (!voicing || !voicing.positions) return [];
+
+  const notes = [];
+
+  voicing.positions.forEach((pos) => {
+    // Skip muted strings (fret === null)
+    if (pos.fret === null) return;
+
+    const note = getNoteOnFret(tuning[pos.string], pos.fret);
+    const octave = getOctaveForPosition(pos.string, pos.fret, tuning);
+
+    notes.push({
+      note,
+      octave,
+      stringIndex: pos.string,
+      fret: pos.fret
+    });
+  });
+
+  // Sort by string index (low to high for strumming)
+  return notes.sort((a, b) => a.stringIndex - b.stringIndex);
+}
+
+/**
+ * Create and play a single note
+ * @param {AudioContext} ctx - Web Audio context
+ * @param {string} note - Note name
+ * @param {number} octave - Octave number
+ * @param {number} startTime - When to start playing
+ * @param {Object} options - Playback options
+ * @returns {Object} Reference to oscillator and gain nodes
+ */
+function playNote(ctx, note, octave, startTime, options = {}) {
+  const {
+    volume = 0.2,
+    duration = 0.8,
+    waveform = 'triangle'
+  } = options;
+
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+
+  const frequency = noteToFrequency(note, octave);
+  osc.frequency.value = frequency;
+  osc.type = waveform;
+
+  // Envelope: quick attack, sustain, smooth release
+  const attackTime = 0.01;
+  const releaseTime = 0.1;
+
+  gain.gain.setValueAtTime(0, startTime);
+  gain.gain.linearRampToValueAtTime(volume, startTime + attackTime);
+  gain.gain.setValueAtTime(volume, startTime + duration - releaseTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration);
+
+  osc.start(startTime);
+  osc.stop(startTime + duration);
+
+  return { osc, gain, stopTime: startTime + duration };
+}
+
+/**
+ * Play voicing as a strum (arpeggio from low to high)
+ * @param {AudioContext} ctx - Web Audio context
+ * @param {Object} voicing - Voicing object
+ * @param {Array<string>} tuning - Current tuning
+ * @param {Object} options - Playback options
+ * @returns {Array} Array of active node references
+ */
+export function playVoicingStrum(ctx, voicing, tuning, options = {}) {
+  const {
+    volume = 0.25,
+    noteDuration = 0.6,
+    strumDelay = 0.04, // 40ms between notes
+    waveform = 'triangle'
+  } = options;
+
+  if (!ctx || !voicing) return [];
+
+  // Resume audio context if suspended
+  if (ctx.state === 'suspended') {
+    ctx.resume();
+  }
+
+  const notes = getVoicingNotes(voicing, tuning);
+  if (notes.length === 0) return [];
+
+  const now = ctx.currentTime;
+  const activeNodes = [];
+
+  // Per-note volume to prevent clipping
+  const perNoteVolume = volume / Math.sqrt(notes.length);
+
+  notes.forEach((noteData, index) => {
+    const startTime = now + (index * strumDelay);
+
+    const node = playNote(ctx, noteData.note, noteData.octave, startTime, {
+      volume: perNoteVolume,
+      duration: noteDuration,
+      waveform
+    });
+
+    activeNodes.push(node);
+  });
+
+  return activeNodes;
+}
+
+/**
+ * Play voicing simultaneously (all notes at once)
+ * @param {AudioContext} ctx - Web Audio context
+ * @param {Object} voicing - Voicing object
+ * @param {Array<string>} tuning - Current tuning
+ * @param {Object} options - Playback options
+ * @returns {Array} Array of active node references
+ */
+export function playVoicingSimultaneous(ctx, voicing, tuning, options = {}) {
+  const {
+    volume = 0.25,
+    duration = 0.8,
+    waveform = 'triangle'
+  } = options;
+
+  if (!ctx || !voicing) return [];
+
+  // Resume audio context if suspended
+  if (ctx.state === 'suspended') {
+    ctx.resume();
+  }
+
+  const notes = getVoicingNotes(voicing, tuning);
+  if (notes.length === 0) return [];
+
+  const now = ctx.currentTime;
+  const activeNodes = [];
+
+  // Per-note volume to prevent clipping
+  const perNoteVolume = volume / Math.sqrt(notes.length);
+
+  notes.forEach((noteData) => {
+    const node = playNote(ctx, noteData.note, noteData.octave, now, {
+      volume: perNoteVolume,
+      duration,
+      waveform
+    });
+
+    activeNodes.push(node);
+  });
+
+  return activeNodes;
+}
+
+/**
+ * Stop all active nodes immediately
+ * @param {Array} activeNodes - Array of node references
+ * @param {AudioContext} ctx - Web Audio context
+ */
+export function stopVoicingPlayback(activeNodes, ctx) {
+  if (!activeNodes || !ctx) return;
+
+  const now = ctx.currentTime;
+  activeNodes.forEach(({ gain, stopTime }) => {
+    if (now < stopTime) {
+      try {
+        gain.gain.setValueAtTime(0, now);
+      } catch (e) {
+        // Node may already be stopped
+      }
+    }
+  });
+}
+
+/**
+ * Create or get AudioContext (handles browser autoplay restrictions)
+ * @returns {AudioContext} Web Audio context
+ */
+export function getAudioContext() {
+  const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+  return new AudioContextClass();
+}


### PR DESCRIPTION
## Summary
- Add play button to hear chord voicings in Learn mode
- Support both strum (arpeggio) and simultaneous chord playback modes
- Uses Web Audio API with proper octave calculation for accurate pitch

## Changes
- New `src/utils/voicingAudio.js` with audio playback utilities
- Updated VoicingControls with play button and Strum/Chord toggle
- Added playback state management in App.jsx

## Test plan
- [ ] Navigate to Learn mode, switch to Chords
- [ ] Click "Voicing" to enable voicing view
- [ ] Verify play button appears next to voicing selector
- [ ] Click play - should hear chord in strum mode (notes played sequentially)
- [ ] Toggle to "Chord" mode and play again - all notes should play simultaneously
- [ ] Test with different voicings (open, barre, triads)
- [ ] Verify muted strings are not played
- [ ] Test with different root notes and chord types

🤖 Generated with [Claude Code](https://claude.ai/code)